### PR TITLE
Ignore missing fields when deserializing

### DIFF
--- a/src/AvroConvert/AvroObjectServices/Read/Resolvers/Record.cs
+++ b/src/AvroConvert/AvroObjectServices/Read/Resolvers/Record.cs
@@ -59,7 +59,11 @@ namespace SolTechnology.Avro.AvroObjectServices.Read
                 {
                     string name = rf.Aliases.FirstOrDefault() ?? wf.Name;
 
-                    var memberInfo = typeMembers[name];
+                    if (!typeMembers.TryGetValue(name, out var memberInfo))
+                    {
+                        continue;
+                    }
+
                     object value;
 
                     switch (memberInfo)

--- a/tests/AvroConvertTests/Headless/HeadlessComponentTests.cs
+++ b/tests/AvroConvertTests/Headless/HeadlessComponentTests.cs
@@ -31,5 +31,23 @@ namespace AvroConvertComponentTests.Headless
             Assert.Equal(toSerialize.andLongProperty, deserialized.andLongProperty);
             Assert.Equal(toSerialize.justSomeProperty, deserialized.justSomeProperty);
         }
+
+        [Fact]
+        public void Component_DeserializeWithMissingFields_NoError()
+        {
+            //Arrange
+            BaseTestClass toSerialize = _fixture.Create<BaseTestClass>();
+            string schema = AvroConvert.GenerateSchema(typeof(BaseTestClass));
+
+            //Act
+            var result = AvroConvert.SerializeHeadless(toSerialize, schema);
+
+            var deserialized = AvroConvert.DeserializeHeadless<ReducedBaseTestClass>(result, schema);
+
+            //Assert
+            Assert.NotNull(result);
+            Assert.NotNull(deserialized);
+            Assert.Equal(toSerialize.justSomeProperty, deserialized.justSomeProperty);
+        }
     }
 }


### PR DESCRIPTION
_Edit: Apologies I accidently deleted my fork and couldn't update the original PR._

This use case for this is when the producer has added a field (and the schema has been updated in the Schema Registry), but consumers are still using classes that don't yet have the field.

This mimics the Avro deserializer, which always looks up the schema by it's `id` in the Schema Registry and then uses that schema string to deserialize. It also replicates the same behavior, since the Avro deserializer will simply ignore any missing fields.