### PR TITLE
Allow generation of nullable reference types

### DIFF
--- a/src/AvroConvert/AvroObjectServices/BuildSchema/AvroContractResolver.cs
+++ b/src/AvroConvert/AvroObjectServices/BuildSchema/AvroContractResolver.cs
@@ -79,11 +79,12 @@ namespace SolTechnology.Avro.AvroObjectServices.BuildSchema
         /// This information is used for creation of the corresponding schema node.
         /// </summary>
         /// <param name="type">The type to resolve.</param>
+        /// <param name="member">The member type containing the type, if specified</param>
         /// <returns>
         /// Serialization information about the type.
         /// </returns>
         /// <exception cref="System.ArgumentNullException">The type argument is null.</exception>
-        internal TypeSerializationInfo ResolveType(Type type)
+        internal TypeSerializationInfo ResolveType(Type type, MemberInfo member = null)
         {
             if (type == null)
             {
@@ -96,7 +97,7 @@ namespace SolTechnology.Avro.AvroObjectServices.BuildSchema
                     string.Format(CultureInfo.InvariantCulture, "Type '{0}' is not supported by the resolver.", type));
             }
 
-            bool isNullable = this._allowNullable || type.CanContainNull();
+            bool isNullable = this._allowNullable || type.CanContainNull() || (!type.IsValueType && member?.IsNullableReferenceType() == true);
 
             if (type.IsInterface() ||
                 type.IsNativelySupported() ||

--- a/src/AvroConvert/AvroObjectServices/BuildSchema/ReflectionSchemaBuilder.cs
+++ b/src/AvroConvert/AvroObjectServices/BuildSchema/ReflectionSchemaBuilder.cs
@@ -138,7 +138,7 @@ namespace SolTechnology.Avro.AvroObjectServices.BuildSchema
                 }
             }
 
-            var typeInfo = this.settings.Resolver.ResolveType(type);
+            var typeInfo = this.settings.Resolver.ResolveType(type, memberInfo);
             if (typeInfo == null)
             {
                 throw new SerializationException(

--- a/src/AvroConvert/Infrastructure/Extensions/MemberInfoExtensions.cs
+++ b/src/AvroConvert/Infrastructure/Extensions/MemberInfoExtensions.cs
@@ -17,11 +17,8 @@ namespace SolTechnology.Avro.Infrastructure.Extensions
 
         private static byte[] GetNullableFlags(MemberInfo member)
         {
-            var attributes = member.GetCustomAttributes(true)
+            var nullableAttribute = member.GetCustomAttributes(true)
                 .OfType<Attribute>()
-                .ToArray();
-
-            var nullableAttribute = attributes
                 .FirstOrDefault(a => a.GetType().FullName == "System.Runtime.CompilerServices.NullableAttribute");
 
             if (nullableAttribute != null)
@@ -31,15 +28,14 @@ namespace SolTechnology.Avro.Infrastructure.Extensions
                     .GetValue(nullableAttribute) ?? EmptyFlags;
             }
 
-            var typeAttributes = member.DeclaringType?.GetCustomAttributes(false);
-
-            var nullableContextAttribute = typeAttributes?
+            var nullableContextAttribute = member.DeclaringType?
+                .GetCustomAttributes(false)
                 .FirstOrDefault(a => a.GetType().FullName == "System.Runtime.CompilerServices.NullableContextAttribute");
 
             if (nullableContextAttribute != null)
             {
                 var value = nullableContextAttribute.GetType()
-                    .GetRuntimeField("Flag")
+                    .GetRuntimeField("Flag")?
                     .GetValue(nullableContextAttribute) ?? 0;
 
                 return new[] {(byte) value};

--- a/src/AvroConvert/Infrastructure/Extensions/MemberInfoExtensions.cs
+++ b/src/AvroConvert/Infrastructure/Extensions/MemberInfoExtensions.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+
+namespace SolTechnology.Avro.Infrastructure.Extensions
+{
+    internal static class MemberInfoExtensions
+    {
+        private static readonly byte[] EmptyFlags = {0};
+
+        internal static bool IsNullableReferenceType(this MemberInfo member)
+        {
+            var nullableFlags = GetNullableFlags(member);
+
+            return nullableFlags.Length > 0 && nullableFlags[0] == 2;
+        }
+
+        private static byte[] GetNullableFlags(MemberInfo member)
+        {
+            var attributes = member.GetCustomAttributes(true)
+                .OfType<Attribute>()
+                .ToArray();
+
+            var nullableAttribute = attributes
+                .FirstOrDefault(a => a.GetType().FullName == "System.Runtime.CompilerServices.NullableAttribute");
+
+            if (nullableAttribute != null)
+            {
+                return (byte[]) nullableAttribute.GetType()
+                    .GetRuntimeField("NullableFlags")?
+                    .GetValue(nullableAttribute) ?? EmptyFlags;
+            }
+
+            var typeAttributes = member.DeclaringType?.GetCustomAttributes(false);
+
+            var nullableContextAttribute = typeAttributes?
+                .FirstOrDefault(a => a.GetType().FullName == "System.Runtime.CompilerServices.NullableContextAttribute");
+
+            if (nullableContextAttribute != null)
+            {
+                var value = nullableContextAttribute.GetType()
+                    .GetRuntimeField("Flag")
+                    .GetValue(nullableContextAttribute) ?? 0;
+
+                return new[] {(byte) value};
+            }
+
+            return EmptyFlags;
+        }
+    }
+}

--- a/tests/AvroConvertTests/GenerateSchemaTests/AttributesClassesTests.cs
+++ b/tests/AvroConvertTests/GenerateSchemaTests/AttributesClassesTests.cs
@@ -130,5 +130,18 @@ namespace AvroConvertComponentTests.GenerateSchemaTests
             // Assert
             Assert.Contains("{\"name\":\"favorite_number\",\"type\":[\"null\",\"int\"]}", schema);
         }
+
+        [Fact]
+        public void GenerateSchema_PropertiesAreNullableReferenceTypes_SchemaIndicatesMembersAreNullable()
+        {
+            //Arrange
+
+            //Act
+            string schema = AvroConvert.GenerateSchema(typeof(ClassWithNullableMembers));
+
+            // Assert
+            Assert.Contains("{\"name\":\"NullableStringProperty\",\"type\":[\"null\",\"string\"]}", schema);
+            Assert.Contains("{\"name\":\"NullableField\",\"type\":[\"null\",\"string\"]}", schema);
+        }
     }
 }

--- a/tests/AvroConvertTests/TestClasses.cs
+++ b/tests/AvroConvertTests/TestClasses.cs
@@ -287,4 +287,14 @@ namespace AvroConvertComponentTests
     {
         public string Name { get; set; }
     }
+
+#nullable enable
+    [Equals(DoNotAddEqualityOperators = true)]
+    public class ClassWithNullableMembers
+    {
+        public string? NullableStringProperty { get; set; }
+
+        public string? NullableField { get; set; }
+    }
+#nullable disable
 }

--- a/tests/AvroConvertTests/TestClasses.cs
+++ b/tests/AvroConvertTests/TestClasses.cs
@@ -294,7 +294,7 @@ namespace AvroConvertComponentTests
     {
         public string? NullableStringProperty { get; set; }
 
-        public string? NullableField { get; set; }
+        public string? NullableField;
     }
 #nullable disable
 }


### PR DESCRIPTION
I know we can use the `[NullableSchema]` attribute for nullable strings, so this is more of a convenience than anything. It also helps to bring it inline with the behavior when specifying `int?` or `bool?` for example.

The ideas for detecting nullable reference types came from here: https://github.com/RicoSuter/Namotion.Reflection
and are documented here: https://github.com/dotnet/roslyn/blob/main/docs/features/nullable-metadata.md