### PR TITLE
Code Generation improvements

### DIFF
--- a/src/AvroConvert/Features/GenerateModel/GenerateModel.cs
+++ b/src/AvroConvert/Features/GenerateModel/GenerateModel.cs
@@ -79,10 +79,7 @@ namespace SolTechnology.Avro.Features.GenerateModel
             {
                 sb.AppendLine($"public enum {@enum.EnumName}");
                 sb.AppendLine("{");
-                foreach (string symbol in @enum.Symbols)
-                {
-                    sb.AppendLine($"	{symbol}");
-                }
+                sb.AppendLine($"	{string.Join(",\r\n	", @enum.Symbols)}");
                 sb.AppendLine("}");
                 sb.AppendLine();
             }

--- a/src/AvroConvert/Features/GenerateModel/GenerateModel.cs
+++ b/src/AvroConvert/Features/GenerateModel/GenerateModel.cs
@@ -69,7 +69,31 @@ namespace SolTechnology.Avro.Features.GenerateModel
                 sb.AppendLine("{");
                 foreach (AvroField field in ac.Fields)
                 {
-                    sb.AppendLine($"	public {field.FieldType} {field.Name} {{ get; set; }}");
+                    if (!string.IsNullOrWhiteSpace(field.Doc))
+                    {
+                        sb.AppendLine("\t/// <summary>");
+                        sb.AppendLine($"\t/// {field.Doc}");
+                        sb.AppendLine("\t/// </summary>");
+                    }
+
+                    string defaultVal = string.Empty;
+                    if (!string.IsNullOrWhiteSpace(field.Default))
+                    {
+                        switch (field.FieldType)
+                        {
+                            case "string":
+                                defaultVal = $" = \"{field.Default}\";";
+                                break;
+                            case "bool":
+                                bool.TryParse(field.Default, out bool parsedVal);
+                                defaultVal = $" = {parsedVal.ToString().ToLower()};";
+                                break;
+                            default:
+                                defaultVal = $" = {field.Default};";
+                                break;
+                        }
+                    }
+                    sb.AppendLine($"	public {field.FieldType} {field.Name} {{ get; set; }}{defaultVal}");
                 }
                 sb.AppendLine("}");
                 sb.AppendLine();
@@ -203,6 +227,16 @@ namespace SolTechnology.Avro.Features.GenerateModel
                     }
 
                     fieldType.Name = field["name"].ToString();
+
+                    if (field["default"] is JValue)
+                    {
+                        fieldType.Default = field["default"].ToString();
+                    }
+
+                    if (field["doc"] is JValue)
+                    {
+                        fieldType.Doc = field["doc"].ToString();
+                    }
 
                     c.Fields.Add(fieldType);
                 }

--- a/src/AvroConvert/Features/GenerateModel/Models/AvroModel.cs
+++ b/src/AvroConvert/Features/GenerateModel/Models/AvroModel.cs
@@ -50,5 +50,7 @@ namespace SolTechnology.Avro.Features.GenerateModel.Models
         public string FieldType { get; set; }
         public string Name { get; set; }
         public string Namespace { get; set; }
+        public string Default { get; set; }
+        public string Doc { get; set; }
     }
 }

--- a/tests/AvroConvertTests/GenerateModel/GenerateModelTests.cs
+++ b/tests/AvroConvertTests/GenerateModel/GenerateModelTests.cs
@@ -84,9 +84,9 @@ resultClass);
                 "\r\n" +
                 "public enum TestEnum\r\n" +
                 "{\r\n" +
-                "\ta\r\n" +
-                "\tbe\r\n" +
-                "\tca\r\n" +
+                "\ta,\r\n" +
+                "\tbe,\r\n" +
+                "\tca,\r\n" +
                 "\tdlo\r\n" +
                 "}\r\n" +
                 "\r\n",
@@ -195,9 +195,9 @@ resultClass);
             Assert.Equal(
                 "public enum TestEnum\r\n" +
                 "{\r\n" +
-                "\ta\r\n" +
-                "\tbe\r\n" +
-                "\tca\r\n" +
+                "\ta,\r\n" +
+                "\tbe,\r\n" +
+                "\tca,\r\n" +
                 "\tdlo\r\n" +
                 "}\r\n" +
                 "\r\n",

--- a/tests/AvroConvertTests/GenerateModel/GenerateModelTests.cs
+++ b/tests/AvroConvertTests/GenerateModel/GenerateModelTests.cs
@@ -401,5 +401,125 @@ resultClass);
                 "\r\n",
                 resultClass);
         }
+
+        [Fact]
+        public void GenerateClass_TheyAreGeneratedWithDocumentation()
+        {
+            //Arrange
+            string schema = @"
+                                {
+          ""type"": ""record"",
+          ""name"": ""Result"",
+          ""fields"": [
+            {
+              ""name"": ""testString"",
+              ""type"": ""string"",
+              ""doc"": ""This is a doc field""
+            },
+            {
+              ""name"": ""testBoolean"",
+              ""type"": ""boolean""
+            },
+            {
+              ""name"": ""testInt"",
+              ""type"": ""int""
+            },
+            {
+              ""name"": ""testLong"",
+              ""type"": ""long""
+            },
+            {
+              ""name"": ""testFloat"",
+              ""type"": ""float""
+            },
+            {
+              ""name"": ""testDouble"",
+              ""type"": ""double""
+            }
+          ]
+        }";
+
+
+            //Act
+            string resultClass = AvroConvert.GenerateModel(schema);
+
+            //Assert
+            Assert.Equal(
+                "public class Result\r\n" +
+                "{\r\n" +
+                "\t/// <summary>\r\n" +
+                "\t/// This is a doc field\r\n" +
+                "\t/// </summary>\r\n" +
+                "\tpublic string testString { get; set; }\r\n" +
+                "\tpublic bool testBoolean { get; set; }\r\n" +
+                "\tpublic int testInt { get; set; }\r\n" +
+                "\tpublic long testLong { get; set; }\r\n" +
+                "\tpublic float testFloat { get; set; }\r\n" +
+                "\tpublic double testDouble { get; set; }\r\n" +
+                "}\r\n" +
+                "\r\n",
+                resultClass);
+        }
+
+
+        [Fact]
+        public void GenerateClass_TheyAreGeneratedWithDefaults()
+        {
+            //Arrange
+            string schema = @"
+                                {
+          ""type"": ""record"",
+          ""name"": ""Result"",
+          ""fields"": [
+            {
+              ""name"": ""testString"",
+              ""type"": ""string"",
+              ""default"": ""Default String""
+            },
+            {
+              ""name"": ""testBoolean"",
+              ""type"": ""boolean"",
+              ""default"": ""TRUE""
+            },
+            {
+              ""name"": ""testInt"",
+              ""type"": ""int"",
+              ""default"": 123
+            },
+            {
+              ""name"": ""testLong"",
+              ""type"": ""long"",
+              ""default"": 123
+            },
+            {
+              ""name"": ""testFloat"",
+              ""type"": ""float"",
+              ""default"": 1.23
+            },
+            {
+              ""name"": ""testDouble"",
+              ""type"": ""double"",
+              ""default"": 1.23
+            }
+          ]
+        }";
+
+            //Act
+            string resultClass = AvroConvert.GenerateModel(schema);
+
+            //Assert
+            Assert.Equal(
+                "public class Result\r\n" +
+                "{\r\n" +
+                "\tpublic string testString { get; set; } = \"Default String\";\r\n" +
+                "\tpublic bool testBoolean { get; set; } = true;\r\n" +
+                "\tpublic int testInt { get; set; } = 123;\r\n" +
+                "\tpublic long testLong { get; set; } = 123;\r\n" +
+                "\tpublic float testFloat { get; set; } = 1.23;\r\n" +
+                "\tpublic double testDouble { get; set; } = 1.23;\r\n" +
+                "}\r\n" +
+                "\r\n",
+                resultClass);
+        }
     }
 }


### PR DESCRIPTION
This PR adds a couple of features when generating code from AVRO Schemas.  If found, it adds default values to properties.  It will also use the doc field, if found, to document the generated code.

```
{
  "type": "record",
  "name": "User",
  "fields": [
    {
      "name": "firstname",
      "type": "string",
      "doc": "The user's firstname"
    },
    {
      "name": "surname",
      "type": "string",
      "doc": "The user's surname"
    },
    {
      "name": "enabled",
      "type": "boolean",
      "default": "TRUE",
      "doc": "The account activation status"
    }
  ]
}
```

```
public class User
{
        /// <summary>
        /// The user's firstname
        /// </summary>
        public string firstname { get; set; }
        /// <summary>
        /// The user's surname
        /// </summary>
        public string surname { get; set; }
        /// <summary>
        /// The account activation status
        /// </summary>
        public bool enabled { get; set; } = true;
}
```

It also fixes a bug where commas were missed when generating enums.