### PR TITLE
Fix avro2json timestamp logical type support

### DIFF
--- a/src/AvroConvert/AvroObjectServices/Schema/TimestampMicrosecondsSchema.cs
+++ b/src/AvroConvert/AvroObjectServices/Schema/TimestampMicrosecondsSchema.cs
@@ -34,8 +34,8 @@ namespace SolTechnology.Avro.AvroObjectServices.Schema
 
         internal override AvroType Type => AvroType.Logical;
         internal override TypeSchema BaseTypeSchema { get; set; }
-        internal override string LogicalTypeName => LogicalTypeEnum.TimeMicrosecond;
-        internal object ConvertToBaseValue(object logicalValue, TimestampMillisecondsSchema schema)
+        internal override string LogicalTypeName => LogicalTypeEnum.TimestampMicroseconds;
+        internal object ConvertToBaseValue(object logicalValue, TimestampMicrosecondsSchema schema)
         {
             DateTime date;
             if (logicalValue is DateTimeOffset dateTimeOffset)
@@ -47,18 +47,17 @@ namespace SolTechnology.Avro.AvroObjectServices.Schema
                 date = ((DateTime)logicalValue);
             }
 
-            var timeDiff = date - DateTimeExtensions.UnixEpochDateTime;
-            return timeDiff.Milliseconds / 1000;
+            return (long)(date - DateTimeExtensions.UnixEpochDateTime).TotalMilliseconds * 1000;
         }
 
         internal override object ConvertToLogicalValue(object baseValue, LogicalTypeSchema schema, Type type)
         {
             var noMicroseconds = (long)baseValue;
-            var result = DateTimeExtensions.UnixEpochDateTime.AddMilliseconds(noMicroseconds * 1000);
+            var result = DateTimeExtensions.UnixEpochDateTime.AddMilliseconds(noMicroseconds / 1000);
 
             if (type == typeof(DateTimeOffset) || type == typeof(DateTimeOffset?))
             {
-                return DateTimeOffset.FromUnixTimeMilliseconds(noMicroseconds * 1000);
+                return DateTimeOffset.FromUnixTimeMilliseconds(noMicroseconds / 1000);
             }
             else
             {

--- a/src/AvroConvert/AvroObjectServices/Schema/TimestampMillisecondsSchema.cs
+++ b/src/AvroConvert/AvroObjectServices/Schema/TimestampMillisecondsSchema.cs
@@ -34,7 +34,7 @@ namespace SolTechnology.Avro.AvroObjectServices.Schema
 
         internal override AvroType Type => AvroType.Logical;
         internal override TypeSchema BaseTypeSchema { get; set; }
-        internal override string LogicalTypeName => "timestamp-millis";
+        internal override string LogicalTypeName => LogicalTypeEnum.TimestampMilliseconds;
 
         internal object ConvertToBaseValue(object logicalValue, TimestampMillisecondsSchema schema)
         {

--- a/src/AvroConvert/AvroObjectServices/Write/Resolver.cs
+++ b/src/AvroConvert/AvroObjectServices/Write/Resolver.cs
@@ -40,6 +40,7 @@ namespace SolTechnology.Avro.AvroObjectServices.Write
         private static readonly Decimal Decimal;
         private static readonly Duration Duration;
         private static readonly TimestampMilliseconds TimestampMilliseconds;
+        private static readonly TimestampMicroseconds TimestampMicroseconds;
 
         static Resolver()
         {
@@ -56,6 +57,7 @@ namespace SolTechnology.Avro.AvroObjectServices.Write
             Decimal = new Decimal();
             Duration = new Duration();
             TimestampMilliseconds = new TimestampMilliseconds();
+            TimestampMicroseconds = new TimestampMicroseconds();
         }
 
         internal static Encoder.WriteItem ResolveWriter(TypeSchema schema)
@@ -90,6 +92,8 @@ namespace SolTechnology.Avro.AvroObjectServices.Write
                                 return Decimal.Resolve((DecimalSchema)logicalTypeSchema);
                             case LogicalTypeSchema.LogicalTypeEnum.TimestampMilliseconds:
                                 return TimestampMilliseconds.Resolve((TimestampMillisecondsSchema)logicalTypeSchema);
+                            case LogicalTypeSchema.LogicalTypeEnum.TimestampMicroseconds:
+                                return TimestampMicroseconds.Resolve((TimestampMicrosecondsSchema)logicalTypeSchema);
                             case LogicalTypeSchema.LogicalTypeEnum.Duration:
                                 return Duration.Resolve((DurationSchema)logicalTypeSchema);
                         }

--- a/src/AvroConvert/AvroObjectServices/Write/Resolvers/TimestampMicroseconds.cs
+++ b/src/AvroConvert/AvroObjectServices/Write/Resolvers/TimestampMicroseconds.cs
@@ -1,0 +1,40 @@
+﻿#region license
+/**Copyright (c) 2021 Adrian Strugala
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+#endregion
+
+using SolTechnology.Avro.AvroObjectServices.Schema;
+using SolTechnology.Avro.Features.Serialize;
+using SolTechnology.Avro.Infrastructure.Exceptions;
+
+namespace SolTechnology.Avro.AvroObjectServices.Write.Resolvers
+{
+    internal class TimestampMicroseconds
+    {
+        internal Encoder.WriteItem Resolve(TimestampMicrosecondsSchema schema)
+        {
+            return (value, encoder) =>
+            {
+                if (!(schema.BaseTypeSchema is LongSchema))
+                {
+                    throw new AvroTypeMismatchException($"[TimestampMicroseconds] required to write against [long] of [Long] schema but found [{schema.BaseTypeSchema}]");
+                }
+
+                var bytesValue = (long)schema.ConvertToBaseValue(value, schema);
+                encoder.WriteLong(bytesValue);
+            };
+        }
+    }
+}

--- a/src/AvroConvert/Features/AvroToJson/Resolver.cs
+++ b/src/AvroConvert/Features/AvroToJson/Resolver.cs
@@ -78,6 +78,8 @@ namespace SolTechnology.Avro.Features.AvroToJson
                     return ResolveMap((MapSchema)readerSchema, d);
                 case AvroType.Union:
                     return ResolveUnion((UnionSchema)readerSchema, d);
+                case AvroType.Logical:
+                    return ResolveLogical((LogicalTypeSchema)readerSchema, d);
                 default:
                     throw new AvroException("Unknown schema type: " + readerSchema);
             }
@@ -185,6 +187,12 @@ namespace SolTechnology.Avro.Features.AvroToJson
             }
 
             return resultSchema;
+        }
+
+        private object ResolveLogical(LogicalTypeSchema readerSchema, IReader reader)
+        {
+            var baseValue = Resolve(readerSchema.BaseTypeSchema, reader);
+            return readerSchema.ConvertToLogicalValue(baseValue, readerSchema, readerSchema.RuntimeType);
         }
     }
 }

--- a/tests/AvroConvertTests/AvroToJson/Avro2JsonTests.cs
+++ b/tests/AvroConvertTests/AvroToJson/Avro2JsonTests.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using Newtonsoft.Json;
 using SolTechnology.Avro;
 using Xunit;
@@ -138,6 +139,25 @@ namespace AvroConvertComponentTests.AvroToJson
 
             //Assert
             Assert.Equal(@"""""", resultJson);
+        }
+
+        [Fact]
+        public void Avro2Json_ConvertDateTime_ProducedDesiredJson()
+        {
+            //Arrange
+            var testObject = new DateTime(2022, 06, 13, 2, 0, 0, DateTimeKind.Utc);
+
+            var expectedJson = JsonConvert.SerializeObject(testObject);
+
+            var avroSerialized = AvroConvert.Serialize(testObject);
+
+
+            //Act
+            var resultJson = AvroConvert.Avro2Json(avroSerialized);
+
+
+            //Assert
+            Assert.Equal(expectedJson, resultJson);
         }
     }
 }

--- a/tests/AvroConvertUnitTests/DeserializeLogicalDateTests.cs
+++ b/tests/AvroConvertUnitTests/DeserializeLogicalDateTests.cs
@@ -1,0 +1,58 @@
+﻿using SolTechnology.Avro;
+using SolTechnology.Avro.AvroObjectServices.BuildSchema;
+using SolTechnology.Avro.AvroObjectServices.Schema;
+using SolTechnology.Avro.AvroObjectServices.Schema.Abstract;
+using SolTechnology.Avro.Features.Serialize;
+using System;
+using System.IO;
+using Xunit;
+using Newtonsoft.Json;
+
+namespace AvroConvertUnitTests
+{
+    public class DeserializeLogicalDateTests
+    {
+        [Fact]
+        public void GivenDateTimeProperty_WhenUsingSchemaWithTimeAsTimestampMicroseconds_ThenShouldWork()
+        {
+            //Arrange
+            var toSerialize = new ClassWithDateTime { ArriveBy = DateTime.UtcNow };
+
+            //Act
+            var schema = Schema.Create(toSerialize);
+
+            // Change schema logical type from timestamp-millis to timestamp-micros (a bit hacky)
+            var schemaJson = schema.ToString().Replace(LogicalTypeSchema.LogicalTypeEnum.TimestampMilliseconds, LogicalTypeSchema.LogicalTypeEnum.TimestampMicroseconds);
+            var microsecondsSchema = new JsonSchemaBuilder().BuildSchema(schemaJson);
+            
+            byte[] result;
+            using (MemoryStream resultStream = new MemoryStream())
+            {
+                using (var writer = new Encoder(microsecondsSchema, resultStream, CodecType.Null))
+                {
+                    writer.Append(toSerialize);
+                }
+                result = resultStream.ToArray();
+            }
+
+            var avro2Json = AvroConvert.Avro2Json(result, microsecondsSchema.ToString());
+            var deserialized = JsonConvert.DeserializeObject<ClassWithDateTime>(avro2Json);
+
+            //Assert
+            Assert.NotNull(result);
+            Assert.NotNull(deserialized);
+            Assert.Equal(toSerialize.ArriveBy.Millisecond, deserialized.ArriveBy.Millisecond);
+            Assert.Equal(toSerialize.ArriveBy.Second, deserialized.ArriveBy.Second);
+            Assert.Equal(toSerialize.ArriveBy.Minute, deserialized.ArriveBy.Minute);
+            Assert.Equal(toSerialize.ArriveBy.Hour, deserialized.ArriveBy.Hour);
+            Assert.Equal(toSerialize.ArriveBy.Day, deserialized.ArriveBy.Day);
+            Assert.Equal(toSerialize.ArriveBy.Month, deserialized.ArriveBy.Month);
+            Assert.Equal(toSerialize.ArriveBy.Year, deserialized.ArriveBy.Year);
+        }
+
+        public class ClassWithDateTime
+        {
+            public DateTime ArriveBy { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
We use AvroConvert.Avro2Json for a bridge between kafka and http apis. Great project!

However, we've come across problems when we use schemas with logical type "timestamp-millis" and "timestamp-micros".

For creating avro messages, we use Chr.Avro - that support these logical types.

This PR implements support for both - supported by tests. 

The test for TimestampMilliseconds is a bit more complicated, since we had to control schema creation.