### PR TITLE
Fix model comma decimal separator + UT's

### DIFF
--- a/src/AvroConvert/Features/GenerateModel/GenerateModel.cs
+++ b/src/AvroConvert/Features/GenerateModel/GenerateModel.cs
@@ -20,6 +20,7 @@
 */
 #endregion
 
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using Newtonsoft.Json;
@@ -189,9 +190,16 @@ namespace SolTechnology.Avro.Features.GenerateModel
 
                     fieldType.Name = field["name"].ToString();
 
-                    if (field["default"] is JValue)
+                    if (field["default"] is JValue _value)
                     {
-                        fieldType.Default = field["default"].ToString();
+                        if(_value.Type != JTokenType.Float)
+                        {
+                            fieldType.Default = field["default"].ToString();
+                        }
+                        else
+                        {
+                            fieldType.Default = _value.ToString(NumberFormatInfo.InvariantInfo);
+                        }                        
                     }
 
                     if (field["doc"] is JValue)

--- a/tests/AvroConvertTests/GenerateModel/GenerateModelTests.cs
+++ b/tests/AvroConvertTests/GenerateModel/GenerateModelTests.cs
@@ -1,4 +1,6 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
+using System.Threading;
 using SolTechnology.Avro;
 using Xunit;
 
@@ -539,6 +541,59 @@ resultClass);
                 "\tpublic bool testBoolean { get; set; } = true;\r\n" +
                 "\tpublic int testInt { get; set; } = 123;\r\n" +
                 "\tpublic long testLong { get; set; } = 123;\r\n" +
+                "\tpublic float testFloat { get; set; } = 1.23;\r\n" +
+                "\tpublic double testDouble { get; set; } = 1.23;\r\n" +
+                "}\r\n" +
+                "\r\n",
+                resultClass);
+        }
+
+
+        [Fact]
+        public void GenerateClass_CommaNumberDecimalSeparator()
+        {
+            //Arrange
+            string schema = @"
+                                {
+          ""type"": ""record"",
+          ""name"": ""Result"",
+          ""fields"": [
+            {
+              ""name"": ""testFloat"",
+              ""type"": ""float"",
+              ""default"": 1.23
+            },
+            {
+              ""name"": ""testDouble"",
+              ""type"": ""double"",
+              ""default"": 1.23
+            }
+          ]
+        }";
+
+            string resultClass = null;
+            var tempCulture = Thread.CurrentThread.CurrentCulture;
+
+            //Act
+
+            try
+            {
+                Thread.CurrentThread.CurrentCulture = new System.Globalization.CultureInfo("de");
+                resultClass = AvroConvert.GenerateModel(schema);
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail(ex.Message);
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentCulture = tempCulture;
+            }
+
+            //Assert
+            Assert.Equal(
+                "public class Result\r\n" +
+                "{\r\n" +
                 "\tpublic float testFloat { get; set; } = 1.23;\r\n" +
                 "\tpublic double testDouble { get; set; } = 1.23;\r\n" +
                 "}\r\n" +


### PR DESCRIPTION
I have failed the test 'GenerateClass_TheyAreGeneratedWithDefaults' because my current culture uses a comma as the decimal separator, and the generated default value for C# model because of this also uses a comma as the separator. This results in an invalid C# code.

`public double testDouble { get; set; } = 1,23;  // invalid C# code.`


