### PR TITLE
Fix nullable short and ushort int16 not found exception on serialization

### DIFF
--- a/src/AvroConvert/AvroObjectServices/Write/Resolvers/Union.cs
+++ b/src/AvroConvert/AvroObjectServices/Write/Resolvers/Union.cs
@@ -57,7 +57,7 @@ namespace SolTechnology.Avro.AvroObjectServices.Write.Resolvers
                 case AvroType.Boolean:
                     return obj is bool;
                 case AvroType.Int:
-                    return obj is int;
+                    return (obj is short) || (obj is ushort) || (obj is int);
                 case AvroType.Long:
                     return obj is long;
                 case AvroType.Float:

--- a/tests/AvroConvertTests/DefaultSerializationDeserialization/PrimitiveTypesTests.cs
+++ b/tests/AvroConvertTests/DefaultSerializationDeserialization/PrimitiveTypesTests.cs
@@ -38,16 +38,40 @@ namespace AvroConvertComponentTests.DefaultSerializationDeserialization
             //Arrange
             var underTest = new SpecimenContext(_fixture).Resolve(type);
 
-
             //Act
             var serialized = AvroConvert.Serialize(underTest);
             var deserialized = AvroConvert.Deserialize(serialized, type);
-
 
             //Assert
             Assert.NotNull(serialized);
             Assert.NotNull(deserialized);
             Assert.Equal(underTest, deserialized);
+        }
+
+        [Fact]
+        public void Ensure_that_short_int16_primitive_type_is_supported()
+        {
+            // Arrange
+            var model = new ClassWithShortInt16();
+            model.ShortValue = 1;
+            model.ShortValueNullable = 1;
+            model.UShortValue = 1;
+            model.UShortValueNullable = 1;
+
+            // Act
+            var serializedModel = AvroConvert.Serialize(model);
+            var deserializedModel = AvroConvert.Deserialize<ClassWithShortInt16>(serializedModel);
+
+            // Assert
+            Assert.Equivalent(model, deserializedModel);
+        }
+
+        public class ClassWithShortInt16
+        {
+            public short ShortValue { get; set; }
+            public short? ShortValueNullable { get; set; }
+            public ushort UShortValue { get; set; }
+            public ushort? UShortValueNullable { get; set; }
         }
 
         [Fact]

--- a/tests/AvroConvertUnitTests/DeserializeLogicalDateTests.cs
+++ b/tests/AvroConvertUnitTests/DeserializeLogicalDateTests.cs
@@ -1,8 +1,6 @@
 ﻿using SolTechnology.Avro;
 using SolTechnology.Avro.AvroObjectServices.BuildSchema;
-using SolTechnology.Avro.Features.Serialize;
 using System;
-using System.IO;
 using Xunit;
 using Newtonsoft.Json;
 using SolTechnology.Avro.AvroObjectServices.Schemas.Abstract;


### PR DESCRIPTION
Suggesting the following fix for [issue#109](https://github.com/AdrianStrugala/AvroConvert/issues/109).

I suppose alternative way to do it would be to add AvroType (and Schema) for Short type, but since Apache Avro does not seem to relate directly to short type in their list of supported types, this is a quick fix for the serialization issue at hand.

Any improvements/feedback to the suggested fix here?

Also note that I initially expanded the _AvroConvertComponentTests-DefaultSerializationDeserialization-PrimitiveTypesTests_ _"Ensure_that_various_primitive_types_are_supported"_ test with nullable short and ushort types as InlineData, but this test was not able to reproduce the bug (neither with Assert.Equal or Assert.Equivalent). Hence, created a new separate test for this specific bug. 

**Changes**
- Fix serialization exception for nullable short and ushort int16 types
- Added tests to verify the bug, then implemented the fix, also confirming old and new tests are working
- Removed / cleaned up unused using references