### PR TITLE
Changing Uuid to be written as underlying bytes

### DIFF
--- a/AvroConvert.sln
+++ b/AvroConvert.sln
@@ -45,6 +45,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AvroConvertUnitTests", "tes
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Profiler", "tests\Profiler\Profiler.csproj", "{F2E89AF6-EFDD-4233-A15D-3AE4D5CFE48F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoreBenchmarks", "tests\CoreBenchmarks\CoreBenchmarks\CoreBenchmarks.csproj", "{ADAE7FF2-F659-43D8-B826-D6D2C477E596}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -187,6 +189,18 @@ Global
 		{F2E89AF6-EFDD-4233-A15D-3AE4D5CFE48F}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{F2E89AF6-EFDD-4233-A15D-3AE4D5CFE48F}.Release|x86.ActiveCfg = Release|Any CPU
 		{F2E89AF6-EFDD-4233-A15D-3AE4D5CFE48F}.Release|x86.Build.0 = Release|Any CPU
+		{ADAE7FF2-F659-43D8-B826-D6D2C477E596}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ADAE7FF2-F659-43D8-B826-D6D2C477E596}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ADAE7FF2-F659-43D8-B826-D6D2C477E596}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{ADAE7FF2-F659-43D8-B826-D6D2C477E596}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{ADAE7FF2-F659-43D8-B826-D6D2C477E596}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{ADAE7FF2-F659-43D8-B826-D6D2C477E596}.Debug|x86.Build.0 = Debug|Any CPU
+		{ADAE7FF2-F659-43D8-B826-D6D2C477E596}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ADAE7FF2-F659-43D8-B826-D6D2C477E596}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ADAE7FF2-F659-43D8-B826-D6D2C477E596}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{ADAE7FF2-F659-43D8-B826-D6D2C477E596}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{ADAE7FF2-F659-43D8-B826-D6D2C477E596}.Release|x86.ActiveCfg = Release|Any CPU
+		{ADAE7FF2-F659-43D8-B826-D6D2C477E596}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -200,6 +214,7 @@ Global
 		{7952E832-F277-4387-A1B1-40EF9EC9DFDF} = {CCBD5998-CCF4-48BA-B80E-716F68613375}
 		{E4D7C0E6-D268-4B3D-A654-D86235828940} = {CCBD5998-CCF4-48BA-B80E-716F68613375}
 		{F2E89AF6-EFDD-4233-A15D-3AE4D5CFE48F} = {78EEDAB3-E0F3-4BDC-AB47-C5FBF60417B8}
+		{ADAE7FF2-F659-43D8-B826-D6D2C477E596} = {78EEDAB3-E0F3-4BDC-AB47-C5FBF60417B8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F9BF1700-C9CB-438A-B3CD-601762B9DCB2}

--- a/src/AvroConvert/AvroObjectServices/Schemas/UuidSchema.cs
+++ b/src/AvroConvert/AvroObjectServices/Schemas/UuidSchema.cs
@@ -17,8 +17,6 @@
 
 using System;
 using SolTechnology.Avro.AvroObjectServices.Schemas.Abstract;
-using SolTechnology.Avro.AvroObjectServices.Write;
-using SolTechnology.Avro.Infrastructure.Exceptions;
 
 namespace SolTechnology.Avro.AvroObjectServices.Schemas
 {
@@ -30,7 +28,7 @@ namespace SolTechnology.Avro.AvroObjectServices.Schemas
         }
         public UuidSchema(Type runtimeType) : base(runtimeType)
         {
-            BaseTypeSchema = new StringSchema();
+            BaseTypeSchema = new BytesSchema();
         }
 
         internal override AvroType Type => AvroType.Logical;
@@ -43,7 +41,7 @@ namespace SolTechnology.Avro.AvroObjectServices.Schemas
                 return baseValue;
             else
             {
-                return Guid.Parse((string)baseValue);
+                return new Guid((byte[])baseValue);
             }
         }
     }

--- a/src/AvroConvert/AvroObjectServices/Write/IWriter.cs
+++ b/src/AvroConvert/AvroObjectServices/Write/IWriter.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 
 namespace SolTechnology.Avro.AvroObjectServices.Write
@@ -47,8 +48,13 @@ namespace SolTechnology.Avro.AvroObjectServices.Write
         /// Bytes are encoded as a long followed by that many bytes of data.
         /// </summary>
         /// <param name="value"></param>
-        /// 
         void WriteBytes(byte[] value);
+
+        /// <summary>
+        /// Bytes are encoded as a long followed by that many bytes of data.
+        /// </summary>
+        /// <param name="buffer"></param>
+        void WriteBytes(ReadOnlySpan<byte> buffer);
 
         /// <summary>
         /// A string is encoded as a long followed by

--- a/src/AvroConvert/AvroObjectServices/Write/Resolvers/Uuid.cs
+++ b/src/AvroConvert/AvroObjectServices/Write/Resolvers/Uuid.cs
@@ -34,7 +34,13 @@ namespace SolTechnology.Avro.AvroObjectServices.Write
                     throw new AvroTypeMismatchException($"[Guid] required to write against [string] of [Uuid] schema but found [{value.GetType()}]");
                 }
 
-                encoder.WriteString(guid.ToString());
+#if NET6_0_OR_GREATER
+                Span<byte> buffer = stackalloc byte[16];
+                guid.TryWriteBytes(buffer);
+                encoder.WriteBytes(buffer);
+#else
+                encoder.WriteBytes(guid.ToByteArray());
+#endif
             };
         }
     }

--- a/src/AvroConvert/AvroObjectServices/Write/Writer.cs
+++ b/src/AvroConvert/AvroObjectServices/Write/Writer.cs
@@ -76,7 +76,6 @@ namespace SolTechnology.Avro.AvroObjectServices.Write
             WriteByte((byte)n);
         }
 
-
         public void WriteFloat(float value)
         {
             byte[] buffer = BitConverter.GetBytes(value);
@@ -107,6 +106,13 @@ namespace SolTechnology.Avro.AvroObjectServices.Write
             WriteLong(value.Length);
             WriteBytesRaw(value);
         }
+
+        public void WriteBytes(ReadOnlySpan<byte> buffer)
+        {
+            WriteLong(buffer.Length);
+            WriteBytesRaw(buffer);
+        }
+
         public void WriteStream(MemoryStream stream)
         {
             WriteLong(stream.Length);
@@ -174,6 +180,15 @@ namespace SolTechnology.Avro.AvroObjectServices.Write
         public void WriteBytesRaw(byte[] bytes)
         {
             _stream.Write(bytes, 0, bytes.Length);
+        }
+
+        public void WriteBytesRaw(ReadOnlySpan<byte> bytes)
+        {
+#if NET6_0_OR_GREATER
+            _stream.Write(bytes);
+#else
+            throw new NotImplementedException();
+#endif
         }
 
         private void WriteByte(byte b)

--- a/tests/AvroConvertTests/GenerateSchema/LogicalTypeTests.cs
+++ b/tests/AvroConvertTests/GenerateSchema/LogicalTypeTests.cs
@@ -7,8 +7,8 @@ namespace AvroConvertComponentTests.GenerateSchema
     public class LogicalTypeTests
     {
         [Theory]
-        [InlineData(typeof(Guid?), @"[""null"",{""type"":""string"",""logicalType"":""uuid""}]")]
-        [InlineData(typeof(Guid), @"{""type"":""string"",""logicalType"":""uuid""}")]
+        [InlineData(typeof(Guid?), @"[""null"",{""type"":""bytes"",""logicalType"":""uuid""}]")]
+        [InlineData(typeof(Guid), @"{""type"":""bytes"",""logicalType"":""uuid""}")]
         [InlineData(typeof(DateTime?), @"[""null"",{""type"":""long"",""logicalType"":""timestamp-micros""}]")]
         [InlineData(typeof(DateTime), @"{""type"":""long"",""logicalType"":""timestamp-micros""}")]
         [InlineData(typeof(TimeSpan?), @"[""null"",{""type"":""fixed"",""size"":12,""name"":""duration"",""logicalType"":""duration""}]")]

--- a/tests/CoreBenchmarks/CoreBenchmarks/CoreBenchmarks.csproj
+++ b/tests/CoreBenchmarks/CoreBenchmarks/CoreBenchmarks.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="BenchmarkDotNet" Version="0.13.9" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\..\..\src\AvroConvert\AvroConvert.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/tests/CoreBenchmarks/CoreBenchmarks/Program.cs
+++ b/tests/CoreBenchmarks/CoreBenchmarks/Program.cs
@@ -1,0 +1,3 @@
+﻿using BenchmarkDotNet.Running;
+
+BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

--- a/tests/CoreBenchmarks/CoreBenchmarks/WriterBenchmarks.Uuid.cs
+++ b/tests/CoreBenchmarks/CoreBenchmarks/WriterBenchmarks.Uuid.cs
@@ -1,0 +1,26 @@
+﻿using System.Text;
+using BenchmarkDotNet.Attributes;
+
+namespace CoreBenchmarks
+{
+    [MemoryDiagnoser]
+    public class WriterBenchmarksUuid
+    {
+        // storing as string also shrinks it from 36 to 16 bytes
+        private readonly Guid _guid = Guid.NewGuid();
+
+        [Benchmark(Baseline = true)]
+        public int WriteUuid_Old() =>
+            Encoding.UTF8.GetBytes(_guid.ToString()).Length;
+
+        [Benchmark]
+        public int WriteUuid_Bytes() => _guid.ToByteArray().Length;
+
+        [Benchmark]
+        public bool WriteUuid_New()
+        {
+            Span<byte> buffer = stackalloc byte[16];
+            return _guid.TryWriteBytes(buffer);
+        }
+    }
+}


### PR DESCRIPTION
Changing Uuid to be stored as Guid's underlying bytes which would remove overhead of serializing to UTF8 string.
As a result serialized byte length shrinks from 36 bytes to 16 bytes as well as speeding up serialization of Uuid fields.

`CoreBenchmarks` project is meant to house benchmarks for core pieces of library.
Running Uuid benchmark `dotnet run -c Release --filter "*WriterBenchmarksUuid*"` produces the following output

| Method          | Mean       | Error     | StdDev    | Median     | Ratio | Gen0   | Allocated | Alloc Ratio |
|---------------- |-----------:|----------:|----------:|-----------:|------:|-------:|----------:|------------:|
| WriteUuid_Old   | 57.9692 ns | 1.3138 ns | 3.7269 ns | 57.9127 ns |  1.00 | 0.0382 |     160 B |        1.00 |
| WriteUuid_Bytes |  4.7714 ns | 0.1217 ns | 0.1895 ns |  4.7659 ns |  0.09 | 0.0096 |      40 B |        0.25 |
| WriteUuid_New   |  0.9664 ns | 0.0449 ns | 0.0977 ns |  0.9309 ns |  0.02 |      - |         - |        0.00 |

PR is introducing overloads of `WriteBytes` and `WriteBytesRaw` methods to work with `Span` based APIs.