### PR TITLE
Making getters dictionary static

### DIFF
--- a/src/AvroConvert/AvroObjectServices/Write/Resolvers/Record.cs
+++ b/src/AvroConvert/AvroObjectServices/Write/Resolvers/Record.cs
@@ -74,7 +74,7 @@ namespace SolTechnology.Avro.AvroObjectServices.Write
             var type = recordObj.GetType();
             var typeHash = type.GetHashCode();
 
-            var lazyGetters = gettersDictionary.GetOrAdd(typeHash, new Lazy<Func<object, string, object>>(() => GenerateGetValue(type), LazyThreadSafetyMode.PublicationOnly));
+            var lazyGetters = gettersDictionary.GetOrAdd(typeHash, new Lazy<Func<object, string, object>>(() => GenerateGetValue(type), LazyThreadSafetyMode.ExecutionAndPublication));
             Func<object, string, object> getters = lazyGetters.Value;
 
             foreach (var writer in writers)


### PR DESCRIPTION
This PR introduces 2 small improvements.

First is making `gettersDictionary` static, so that it is reused across `AvroConvert.Serialize` calls, e.g. currently this will cause `gettersDictionary` to be populated on each `AvroConvert.Serialize` call
```
var users = new List<User>();
AvroConvert.Serialize(users);
AvroConvert.Serialize(users);
```

Making it static will ensure it is populated only once. Given that `GenerateGetValue` is an expensive operation eliminating its execution would improve performance.

Second suggested improvement is `gettersDictionary` population if race conditions occur. Normally if 2 or more threads try to execute `GenerateGetValue` concurrently to store the value in dictionary, all of them will execute but only single return value will be used. Since `GenerateGetValue` is an expensive operation, using `Lazy` as its value will ensure that even if multiple threads try to create value, they will create `Lazy` instance which is much cheaper. Later on when value is accessed, `Lazy` will ensure only 1 `GenerateGetValue` is executed avoiding to run multiple expensive operations altogether. [See this blog post](https://andrewlock.net/making-getoradd-on-concurrentdictionary-thread-safe-using-lazy/) for more details about this  improvement.

