### PR TITLE
Added an UUID Schema parser to the DefaultValueResolver

### DIFF
--- a/src/AvroConvert/AvroObjectServices/BuildSchema/DefaultValueResolver.cs
+++ b/src/AvroConvert/AvroObjectServices/BuildSchema/DefaultValueResolver.cs
@@ -25,191 +25,201 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using SolTechnology.Avro.AvroObjectServices.Schemas;
 using SolTechnology.Avro.AvroObjectServices.Schemas.Abstract;
-using SolTechnology.Avro.AvroObjectServices.Schemas.AvroTypes;
 
-namespace SolTechnology.Avro.AvroObjectServices.BuildSchema
+namespace SolTechnology.Avro.AvroObjectServices.BuildSchema;
+
+/// <summary>
+/// This class is responsible for parsing a JSON string according to a given JSON
+/// schema and returning the corresponding C# value as object.
+/// </summary>
+internal sealed class DefaultValueResolver
 {
-    /// <summary>
-    /// This class is responsible for parsing a JSON string according to a given JSON 
-    /// schema and returning the corresponding C# value as object.
-    /// </summary>
-    internal sealed class DefaultValueResolver
+    private readonly Dictionary<Type, Func<string, object>> parsersWithoutSchema;
+    private readonly Dictionary<Type, Func<TypeSchema, string, object>> parsersWithSchema;
+
+    internal DefaultValueResolver()
     {
-        private readonly Dictionary<Type, Func<string, object>> parsersWithoutSchema;
-        private readonly Dictionary<Type, Func<TypeSchema, string, object>> parsersWithSchema;
-
-        internal DefaultValueResolver()
+        this.parsersWithoutSchema = new Dictionary<Type, Func<string, object>>
         {
-            this.parsersWithoutSchema = new Dictionary<Type, Func<string, object>>
-            {
-                { typeof(BooleanSchema), json => ConvertTo<bool>(json) },
-                { typeof(IntSchema), json => ConvertTo<int>(json) },
-                { typeof(LongSchema), json => ConvertTo<long>(json) },
-                { typeof(FloatSchema), json => ConvertTo<float>(json) },
-                { typeof(DoubleSchema), json => ConvertTo<double>(json) },
-                { typeof(StringSchema), json => json },
-                { typeof(BytesSchema), ConvertToBytes },
-                { typeof(NullSchema), this.ParseNull }
-            };
+            { typeof(BooleanSchema), json => ConvertTo<bool>(json) },
+            { typeof(IntSchema), json => ConvertTo<int>(json) },
+            { typeof(LongSchema), json => ConvertTo<long>(json) },
+            { typeof(FloatSchema), json => ConvertTo<float>(json) },
+            { typeof(DoubleSchema), json => ConvertTo<double>(json) },
+            { typeof(StringSchema), json => json },
+            { typeof(BytesSchema), ConvertToBytes },
+            { typeof(NullSchema), this.ParseNull },
+            { typeof(UuidSchema), this.ParseUuid },
+        };
 
-            this.parsersWithSchema = new Dictionary<Type, Func<TypeSchema, string, object>>
-            {
-                { typeof(EnumSchema), this.ParseEnum },
-                { typeof(ArraySchema), this.ParseArray },
-                { typeof(UnionSchema), this.ParseUnion },
-                { typeof(MapSchema), this.ParseMap },
-                { typeof(RecordSchema), this.ParseRecord },
-                { typeof(FixedSchema), this.ParseFixed },
-            };
+        this.parsersWithSchema = new Dictionary<Type, Func<TypeSchema, string, object>>
+        {
+            { typeof(EnumSchema), this.ParseEnum },
+            { typeof(ArraySchema), this.ParseArray },
+            { typeof(UnionSchema), this.ParseUnion },
+            { typeof(MapSchema), this.ParseMap },
+            { typeof(RecordSchema), this.ParseRecord },
+            { typeof(FixedSchema), this.ParseFixed }
+        };
+    }
+
+    /// <summary>
+    /// Parses a JSON string according to given schema and returns the corresponding object.
+    /// </summary>
+    /// <param name="schema">The schema.</param>
+    /// <param name="json">The JSON object.</param>
+    /// <returns>The object.</returns>
+    internal object Parse(TypeSchema schema, string json)
+    {
+        if (this.parsersWithoutSchema.ContainsKey(schema.GetType()))
+        {
+            return this.parsersWithoutSchema[schema.GetType()](json);
         }
 
-        /// <summary>
-        /// Parses a JSON string according to given schema and returns the corresponding object.
-        /// </summary>
-        /// <param name="schema">The schema.</param>
-        /// <param name="json">The JSON object.</param>
-        /// <returns>The object.</returns>
-        internal object Parse(TypeSchema schema, string json)
+        if (this.parsersWithSchema.ContainsKey(schema.GetType()))
         {
-            if (this.parsersWithoutSchema.ContainsKey(schema.GetType()))
-            {
-                return this.parsersWithoutSchema[schema.GetType()](json);
-            }
+            return this.parsersWithSchema[schema.GetType()](schema, json);
+        }
 
-            if (this.parsersWithSchema.ContainsKey(schema.GetType()))
-            {
-                return this.parsersWithSchema[schema.GetType()](schema, json);
-            }
+        throw new SerializationException(
+            string.Format(CultureInfo.InvariantCulture, "Unknown schema type '{0}'.", schema.GetType()));
+    }
 
+    private object ParseNull(string json)
+    {
+        if (!string.IsNullOrEmpty(json))
+        {
             throw new SerializationException(
-                string.Format(CultureInfo.InvariantCulture, "Unknown schema type '{0}'.", schema.GetType()));
+                string.Format(CultureInfo.InvariantCulture, "'{0}' is not valid. Null is expected.", json));
+        }
+        return null;
+    }
+
+    private object ParseEnum(TypeSchema schema, string jsonObject)
+    {
+        var enumSchema = (EnumSchema)schema;
+        string enumValue;
+
+        if (int.TryParse(jsonObject, out var index))
+        {
+            enumValue = enumSchema.GetSymbolByValue(index);
+        }
+        else if (!enumSchema.Symbols.Contains(jsonObject))
+        {
+            throw new SerializationException(
+                string.Format(CultureInfo.InvariantCulture, "'{0}' is not a valid enum value.", jsonObject));
+        }
+        else
+        {
+            enumValue = jsonObject;
         }
 
-        private object ParseNull(string json)
+        return enumValue;
+    }
+
+    private object[] ParseArray(TypeSchema schema, string jsonObject)
+    {
+        var arraySchema = (ArraySchema)schema;
+        return JArray
+            .Parse(jsonObject)
+            .Select(i => this.Parse(arraySchema.ItemSchema, i.ToString()))
+            .ToArray();
+    }
+
+    private object ParseUnion(TypeSchema schema, string jsonObject)
+    {
+        var unionSchema = (UnionSchema)schema;
+        return this.Parse(unionSchema.Schemas[0], jsonObject);
+    }
+
+    private Dictionary<string, object> ParseMap(TypeSchema schema, string jsonObject)
+    {
+        var mapSchema = (MapSchema)schema;
+        return JsonConvert
+            .DeserializeObject<Dictionary<string, JToken>>(jsonObject)
+            .Select(d => new { d.Key, Value = this.Parse(mapSchema.ValueSchema, d.Value.ToString()) })
+            .ToDictionary(o => o.Key, o => o.Value);
+    }
+
+    private Dictionary<string, object> ParseRecord(TypeSchema schema, string jsonObject)
+    {
+        var recordSchema = (RecordSchema)schema;
+        var result = new Dictionary<string, object>();
+
+        var data = JsonConvert.DeserializeObject<Dictionary<string, JToken>>(jsonObject);
+
+        foreach (var datum in data)
         {
-            if (!string.IsNullOrEmpty(json))
+            var matchedRecord = recordSchema.Fields.FirstOrDefault(field => field.Name == datum.Key);
+            if (matchedRecord == null)
             {
                 throw new SerializationException(
-                    string.Format(CultureInfo.InvariantCulture, "'{0}' is not valid. Null is expected.", json));
+                    string.Format(CultureInfo.InvariantCulture,
+                                  "Could not set default value because JSON object contains fields that do not exist in the schema."));
             }
-            return null;
+            result[matchedRecord.Name] = this.Parse(matchedRecord.TypeSchema, datum.Value.ToString());
         }
 
-        private object ParseEnum(TypeSchema schema, string jsonObject)
+        return result;
+    }
+
+    private byte[] ParseFixed(TypeSchema schema, string jsonObject)
+    {
+        var fixedSchema = (FixedSchema)schema;
+        var result = ConvertToBytes(jsonObject);
+
+        if (result.Length != fixedSchema.Size)
         {
-            var enumSchema = (EnumSchema)schema;
-            string enumValue;
-
-            if (int.TryParse(jsonObject, out var index))
-            {
-                enumValue = enumSchema.GetSymbolByValue(index);
-            }
-            else if (!enumSchema.Symbols.Contains(jsonObject))
-            {
-                throw new SerializationException(
-                    string.Format(CultureInfo.InvariantCulture, "'{0}' is not a valid enum value.", jsonObject));
-            }
-            else
-            {
-                enumValue = jsonObject;
-            }
-
-            return enumValue;
+            throw new SerializationException(
+                string.Format(CultureInfo.InvariantCulture, "'{0}' size does not match the size of fixed schema node.", jsonObject));
         }
 
-        private object[] ParseArray(TypeSchema schema, string jsonObject)
+        return result;
+    }
+
+    private object ParseUuid(string json)
+    {
+        if (Guid.TryParse(json, out var guid))
         {
-            var arraySchema = (ArraySchema)schema;
-            return JArray
-                .Parse(jsonObject)
-                .Select(i => this.Parse(arraySchema.ItemSchema, i.ToString()))
-                .ToArray();
+            return guid;
         }
 
-        private object ParseUnion(TypeSchema schema, string jsonObject)
+        throw new SerializationException(
+            string.Format(CultureInfo.InvariantCulture, "'{0}' is not a valid GUID", json));
+    }
+
+    private static byte[] ConvertToBytes(string jsonObject)
+    {
+        var result = new List<byte>();
+
+        for (var i = 0; i < jsonObject.Length; i += char.IsSurrogatePair(jsonObject, i) ? 2 : 1)
         {
-            var unionSchema = (UnionSchema)schema;
-            return this.Parse(unionSchema.Schemas[0], jsonObject);
-        }
+            var codepoint = char.ConvertToUtf32(jsonObject, i);
 
-        private Dictionary<string, object> ParseMap(TypeSchema schema, string jsonObject)
-        {
-            var mapSchema = (MapSchema)schema;
-            return JsonConvert
-                .DeserializeObject<Dictionary<string, JToken>>(jsonObject)
-                .Select(d => new { d.Key, Value = this.Parse(mapSchema.ValueSchema, d.Value.ToString()) })
-                .ToDictionary(o => o.Key, o => o.Value);
-        }
-
-        private Dictionary<string, object> ParseRecord(TypeSchema schema, string jsonObject)
-        {
-            var recordSchema = (RecordSchema)schema;
-            var result = new Dictionary<string, object>();
-
-            var data = JsonConvert.DeserializeObject<Dictionary<string, JToken>>(jsonObject);
-
-            foreach (var datum in data)
+            if (codepoint > 255)
             {
-                var matchedRecord = recordSchema.Fields.FirstOrDefault(field => field.Name == datum.Key);
-                if (matchedRecord == null)
-                {
-                    throw new SerializationException(
-                        string.Format(CultureInfo.InvariantCulture,
-                                      "Could not set default value because JSON object contains fields that do not exist in the schema."));
-                }
-                result[matchedRecord.Name] = this.Parse(matchedRecord.TypeSchema, datum.Value.ToString());
+                throw new SerializationException(string.Format(CultureInfo.InvariantCulture, "'{0}' contains invalid characters.", jsonObject));
             }
 
-            return result;
+            result.Add((byte)codepoint);
         }
 
-        private byte[] ParseFixed(TypeSchema schema, string jsonObject)
+        return result.ToArray();
+    }
+
+    private static T ConvertTo<T>(string jsonObject)
+    {
+        // https://github.com/dotnet/corefx/pull/8093
+        var converter = TypeDescriptor.GetConverter(typeof(T));
+        try
         {
-            var fixedSchema = (FixedSchema)schema;
-            var result = ConvertToBytes(jsonObject);
-
-            if (result.Length != fixedSchema.Size)
-            {
-                throw new SerializationException(
-                    string.Format(CultureInfo.InvariantCulture, "'{0}' size does not match the size of fixed schema node.", jsonObject));
-            }
-
-            return result;
+            return (T)converter.ConvertFromString(jsonObject);
         }
-
-        private static byte[] ConvertToBytes(string jsonObject)
+        catch (Exception e)
         {
-            var result = new List<byte>();
-
-            for (var i = 0; i < jsonObject.Length; i += char.IsSurrogatePair(jsonObject, i) ? 2 : 1)
-            {
-                var codepoint = char.ConvertToUtf32(jsonObject, i);
-
-                if (codepoint > 255)
-                {
-                    throw new SerializationException(string.Format(CultureInfo.InvariantCulture, "'{0}' contains invalid characters.", jsonObject));
-                }
-
-                result.Add((byte)codepoint);
-            }
-
-            return result.ToArray();
-        }
-
-        private static T ConvertTo<T>(string jsonObject)
-        {
-            // https://github.com/dotnet/corefx/pull/8093
-            var converter = TypeDescriptor.GetConverter(typeof(T));
-            try
-            {
-                return (T)converter.ConvertFromString(jsonObject);
-            }
-            catch (Exception e)
-            {
-                throw new SerializationException(
-                    string.Format(CultureInfo.InvariantCulture, "Could not parse '{0}' as '{1}'.", jsonObject, typeof(T)),
-                    e);
-            }
+            throw new SerializationException(
+                string.Format(CultureInfo.InvariantCulture, "Could not parse '{0}' as '{1}'.", jsonObject, typeof(T)),
+                e);
         }
     }
 }

--- a/tests/AvroConvertUnitTests/BuildSchemaTests/BuildSchemaTests.cs
+++ b/tests/AvroConvertUnitTests/BuildSchemaTests/BuildSchemaTests.cs
@@ -47,7 +47,7 @@ public sealed class BuildSchemaTests
 
 public class GuidClassWithValidDefaultValue
 {
-    [DefaultValue("00000000-0000-0000-0000-000000000000")]
+    [DefaultValue("dec57724-9fa9-4062-b5a4-e6c41c71e585")]
     public Guid Id { get; set; }
 }
 

--- a/tests/AvroConvertUnitTests/BuildSchemaTests/BuildSchemaTests.cs
+++ b/tests/AvroConvertUnitTests/BuildSchemaTests/BuildSchemaTests.cs
@@ -1,21 +1,58 @@
-﻿using SolTechnology.Avro.AvroObjectServices.BuildSchema;
+﻿using System;
+using System.ComponentModel;
+using System.Runtime.Serialization;
+using SolTechnology.Avro.AvroObjectServices.BuildSchema;
 using Xunit;
 
-namespace AvroConvertUnitTests.BuildSchemaTests
+namespace AvroConvertUnitTests.BuildSchemaTests;
+
+public sealed class BuildSchemaTests
 {
-    public class BuildSchemaTests
+    [Fact]
+    public void BuildSchema_JsonSchemaContainsAvroAttributes_ResultIsEqualToInput()
     {
-        [Fact]
-        public void BuildSchema_JsonSchemaContainsAvroAttributes_ResultIsEqualToInput()
-        {
-            //Arrange
-            var schema = Schema.Create(typeof(AttributeClass));
+        // Arrange
+        var schema = Schema.Create(typeof(AttributeClass));
 
-            //Act
-            var result = Schema.Create(schema.ToString());
+        // Act
+        var result = Schema.Create(schema.ToString());
 
-            //Assert
-            Assert.Equal(schema.ToString(), result.ToString());
-        }
+        // Assert
+        Assert.Equal(schema.ToString(), result.ToString());
     }
+
+    [Fact]
+    public void WhenTheDefaultValueForGUIDIsValid_ThenTheSchemaShouldBeCreated()
+    {
+        // Arrange
+        var schema = Schema.Create(typeof(GuidClassWithValidDefaultValue));
+
+        // Act
+        var resultSchema = Schema.Create(schema.ToString());
+
+        // Assert
+        Assert.Equal(schema.ToString(), resultSchema.ToString());
+    }
+
+    [Fact]
+    public void WhenTheDefaultValueForGuidIsInvalid_ThenAnExceptionShouldBeThrown()
+    {
+        // Arrange
+        var schema = Schema.Create(typeof(GuidClassWithInvalidDefaultValue));
+
+        // Act and Assert
+        Assert.Throws<SerializationException>(() => Schema.Create(schema.ToString()));
+    }
+}
+
+public class GuidClassWithValidDefaultValue
+{
+    [DefaultValue("00000000-0000-0000-0000-000000000000")]
+    public Guid Id { get; set; }
+}
+
+public class GuidClassWithInvalidDefaultValue
+{
+    [DefaultValue("invalid-guid")]
+    public Guid Id { get; set; }
 }


### PR DESCRIPTION
I was having an issue with generating JSON from AVRO. I managed to track down the issue to having a default value for an UUID. 

E.g. for this schema: 
```
{
   "type": "record",
   "name": "RecordName",
   "namespace": "com.example",
   "fields": [
      {
         "name": "some-id",
         "type": {
            "type": "string",
            "logicalType": "uuid"
         },
         "default": "00000000-0000-0000-0000-000000000000"
      }
   ]
}
 ```

I'm not familiar with the project, but I have a proposal for a fix in this PR, which consists of including the `UuidSchema` parser in the `DefaultValueResolver`.

Please let me know if I'm on the right track, and if you have any other suggestions.