### PR TITLE
Duration writer improvements

### DIFF
--- a/src/AvroConvert/AvroConvert.csproj
+++ b/src/AvroConvert/AvroConvert.csproj
@@ -30,6 +30,12 @@
 		</AssemblyAttribute>
 	</ItemGroup>
 
+	<ItemGroup>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+			<_Parameter1>CoreBenchmarks</_Parameter1>
+		</AssemblyAttribute>
+	</ItemGroup>
+
 	<PropertyGroup>
 		<PackageIcon>docs\mini-logo.png</PackageIcon>
 		<PackageIconUrl>https://raw.githubusercontent.com/AdrianStrugala/AvroConvert/master/docs/mini-logo.png</PackageIconUrl>

--- a/src/AvroConvert/AvroObjectServices/Write/IWriter.cs
+++ b/src/AvroConvert/AvroObjectServices/Write/IWriter.cs
@@ -72,6 +72,7 @@ namespace SolTechnology.Avro.AvroObjectServices.Write
         void WriteMapEnd();
         void WriteUnionIndex(int value);
         void WriteFixed(byte[] data);
+        void WriteFixed(ReadOnlySpan<byte> data);
         void WriteFixed(byte[] data, int start, int len);
         void WriteBytesRaw(byte[] bytes);
         void WriteStream(MemoryStream stream);

--- a/src/AvroConvert/AvroObjectServices/Write/Writer.cs
+++ b/src/AvroConvert/AvroObjectServices/Write/Writer.cs
@@ -221,6 +221,15 @@ namespace SolTechnology.Avro.AvroObjectServices.Write
             WriteFixed(data, 0, data.Length);
         }
 
+        public void WriteFixed(ReadOnlySpan<byte> bytes)
+        {
+#if NET6_0_OR_GREATER
+            _stream.Write(bytes);
+#else
+            WriteBytesRaw(bytes.ToArray());
+#endif
+        }
+
         public void WriteFixed(byte[] data, int start, int len)
         {
             _stream.Write(data, start, len);

--- a/tests/CoreBenchmarks/CoreBenchmarks.csproj
+++ b/tests/CoreBenchmarks/CoreBenchmarks.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 
 	<ItemGroup>

--- a/tests/CoreBenchmarks/WriterBenchmarks.Duration.cs
+++ b/tests/CoreBenchmarks/WriterBenchmarks.Duration.cs
@@ -1,0 +1,79 @@
+﻿using System.Runtime.InteropServices;
+using BenchmarkDotNet.Attributes;
+using SolTechnology.Avro.AvroObjectServices.BuildSchema;
+using SolTechnology.Avro.AvroObjectServices.Schemas;
+using SolTechnology.Avro.AvroObjectServices.Write;
+
+namespace CoreBenchmarks;
+
+[MemoryDiagnoser]
+public class WriterBenchmarksDuration
+{
+    private TimeSpan _duration;
+    private WriteResolver _resolver;
+    private DurationSchema _schema;
+    private IWriter _writer;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _duration = TimeSpan.FromDays(37.3d);
+        _schema = (DurationSchema)Schema.Create(_duration);
+        _writer = new Writer(Stream.Null);
+    }
+
+    [Benchmark(Baseline = true)]
+    public int Current()
+    {
+        var duration = _duration;
+
+        var baseSchema = (FixedSchema)_schema.BaseTypeSchema;
+        byte[] bytes = new byte[baseSchema.Size];
+        var monthsBytes = BitConverter.GetBytes(0);
+        var daysBytes = BitConverter.GetBytes(duration.Days);
+
+        var milliseconds = ((duration.Hours * 60 + duration.Minutes) * 60 + duration.Seconds) * 1000 +
+                           duration.Milliseconds;
+        var millisecondsBytes = BitConverter.GetBytes(milliseconds);
+
+
+        Array.Copy(monthsBytes, 0, bytes, 0, 4);
+        Array.Copy(daysBytes, 0, bytes, 4, 4);
+        Array.Copy(millisecondsBytes, 0, bytes, 8, 4);
+
+
+        if (!BitConverter.IsLittleEndian)
+            Array.Reverse(bytes); //reverse it so we get little endian.
+
+        _writer.WriteFixed(bytes);
+        return bytes[0];
+    }
+
+    [Benchmark]
+    public int Optimized()
+    {
+        var duration = _duration;
+
+        var baseSchema = (FixedSchema)_schema.BaseTypeSchema;
+        Span<byte> buffer = stackalloc byte[baseSchema.Size];
+        buffer.Slice(0, 4).Fill(0);
+
+        var days = duration.Days;
+        var daysBytes = MemoryMarshal.AsBytes(MemoryMarshal.CreateSpan(ref days, 1));
+
+        daysBytes.CopyTo(buffer.Slice(4, 4));
+
+        var milliseconds = ((duration.Hours * 60 + duration.Minutes) * 60 + duration.Seconds) * 1000 +
+                           duration.Milliseconds;
+
+        var millisecondsBytes = MemoryMarshal.AsBytes(MemoryMarshal.CreateSpan(ref milliseconds, 1));
+
+        millisecondsBytes.CopyTo(buffer.Slice(8, 4));
+
+        if (!BitConverter.IsLittleEndian)
+            buffer.Reverse();
+
+        _writer.WriteFixed(buffer);
+        return buffer[10];
+    }
+}


### PR DESCRIPTION
This PR reduces allocations and speeds up Duration write resolver.
Benchmark results of current vs optimized

| Method    | Mean     | Error    | StdDev   | Ratio | Gen0   | Allocated | Alloc Ratio |
|---------- |---------:|---------:|---------:|------:|-------:|----------:|------------:|
| Current   | 33.86 ns | 0.119 ns | 0.105 ns |  1.00 | 0.0325 |     136 B |        1.00 |
| Optimized | 12.45 ns | 0.241 ns | 0.226 ns |  0.37 |      - |         - |        0.00 |