### PR TITLE
Reduce allocations & speed up enum writer

### DIFF
--- a/src/AvroConvert/AvroObjectServices/Schemas/EnumSchema.cs
+++ b/src/AvroConvert/AvroObjectServices/Schemas/EnumSchema.cs
@@ -13,7 +13,7 @@
 // See the Apache Version 2.0 License for specific language governing
 // permissions and limitations under the License.
 
-/** Modifications copyright(C) 2020 Adrian Struga³a **/
+/** Modifications copyright(C) 2020 Adrian Strugaï¿½a **/
 
 using System;
 using System.Collections.Generic;
@@ -84,13 +84,11 @@ namespace SolTechnology.Avro.AvroObjectServices.Schemas
             }
         }
         
-        internal ReadOnlyCollection<string> Symbols => new ReadOnlyCollection<string>(this.symbols);
+        internal ReadOnlyCollection<string> Symbols => new (this.symbols);
 
-        internal int GetValueBySymbol(string symbol)
-        {
-            return this.symbolToValue[symbol];
-        }
-
+        internal bool TryGetSymbolValue(string symbol, out int value) =>
+            this.symbolToValue.TryGetValue(symbol, out value);
+        
         internal string GetSymbolByValue(int value)
         {
             return this.valueToSymbol[value];

--- a/src/AvroConvert/AvroObjectServices/Write/Resolvers/Enum.cs
+++ b/src/AvroConvert/AvroObjectServices/Write/Resolvers/Enum.cs
@@ -28,13 +28,13 @@ namespace SolTechnology.Avro.AvroObjectServices.Write
         {
             return (value, e) =>
             {
-                if (!schema.Symbols.Contains(value.ToString()))
+                if (!schema.TryGetSymbolValue(value.ToString(), out var symbolValue))
                 {
                     throw new AvroTypeException(
                         $"[Enum] Provided value is not of the enum [{schema.Name}] members");
                 }
 
-                e.WriteEnum(schema.GetValueBySymbol(value.ToString()));
+                e.WriteEnum(symbolValue);
             };
         }
     }


### PR DESCRIPTION
This PR reduces allocations by changing the check from `schema.Symbols.Contains` which allocates `ReadOnlyCollection` on each access to a `Symbols` property, to a dictionary lookup, which in turn also speeds up Enum writer.

| Method             | Value        | Mean      | Error    | StdDev   | Ratio | Allocated | Alloc Ratio |
|------------------- |------------- |----------:|---------:|---------:|------:|----------:|------------:|
| WriteEnumCurrent   | Professional | 111.98 ns | 1.434 ns | 1.342 ns |  1.00 |      48 B |        1.00 |
| WriteEnumOptimized | Professional |  57.53 ns | 1.114 ns | 1.042 ns |  0.51 |      24 B |        0.50 |

Benchmark used

```
[MemoryDiagnoser(displayGenColumns: false)]
[HideColumns("RatioSD")]
public class WriterBenchmarksEnum
{
    [Params(Level.Professional)]
    public Level Value;
    private EnumSchema _schema;
    private Encoder.WriteItem _writeItemCurrent;
    private Encoder.WriteItem _writeItemOptimized;
    private IWriter _writer;

    [GlobalSetup]
    public void Setup()
    {
        _schema = (EnumSchema)Schema.Create(Value);
        _writeItemCurrent = new WriteResolver().ResolveEnum(_schema);
        _writeItemOptimized = new WriteResolver().ResolveEnumOptimized(_schema);
        _writer = new Writer(Stream.Null);
    }

    [Benchmark(Baseline = true)]
    public void WriteEnumCurrent() =>
        _writeItemCurrent(Value, _writer);
    
    [Benchmark]
    public void WriteEnumOptimized() =>
        _writeItemOptimized(Value, _writer);
}


public enum Level
{
    Expert,
    Professional,
    SemiProfessional,
    Beginner,
    Amateur
}
```