### PR TITLE
Improves uuid writer perf by making use of Utf8Formatter

### DIFF
--- a/src/AvroConvert/AvroObjectServices/Write/Resolvers/Uuid.cs
+++ b/src/AvroConvert/AvroObjectServices/Write/Resolvers/Uuid.cs
@@ -16,6 +16,7 @@
 #endregion
 
 using System;
+using System.Buffers.Text;
 using SolTechnology.Avro.AvroObjectServices.Schemas;
 using SolTechnology.Avro.Features.Serialize;
 using SolTechnology.Avro.Infrastructure.Exceptions;
@@ -34,7 +35,13 @@ namespace SolTechnology.Avro.AvroObjectServices.Write
                     throw new AvroTypeMismatchException($"[Guid] required to write against [string] of [Uuid] schema but found [{value.GetType()}]");
                 }
 
+#if NET6_0_OR_GREATER
+                Span<byte> buffer = stackalloc byte[36];
+                Utf8Formatter.TryFormat(guid, buffer, out _);
+                encoder.WriteBytes(buffer);
+#else
                 encoder.WriteString(guid.ToString());
+#endif
             };
         }
     }


### PR DESCRIPTION
This PR improves Uuid writer by making use of [Utf8Formatter.TryFormat](https://learn.microsoft.com/en-us/dotnet/api/system.buffers.text.utf8formatter.tryformat?view=net-6.0#system-buffers-text-utf8formatter-tryformat) which Formats a `Guid` as a UTF8 string and allows to write bytes directly to a destination `Span`.

| Method    | Mean     | Error    | StdDev   | Ratio | Gen0   | Allocated | Alloc Ratio |
|---------- |---------:|---------:|---------:|------:|-------:|----------:|------------:|
| Current   | 47.04 ns | 0.309 ns | 0.289 ns |  1.00 | 0.0306 |     128 B |        1.00 |
| Optimized | 30.12 ns | 0.102 ns | 0.095 ns |  0.64 | 0.0076 |      32 B |        0.25 |