### PR TITLE
Reduce allocations of Record/Array readers

### DIFF
--- a/src/AvroConvert/AvroObjectServices/Schemas/RecordFieldSchema.cs
+++ b/src/AvroConvert/AvroObjectServices/Schemas/RecordFieldSchema.cs
@@ -17,6 +17,7 @@
 
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Reflection;
 using Newtonsoft.Json;
 using SolTechnology.Avro.AvroObjectServices.BuildSchema;
@@ -39,6 +40,7 @@ namespace SolTechnology.Avro.AvroObjectServices.Schemas
         internal int Position { get; }
         internal NamedEntityAttributes NamedEntityAttributes { get; }
 
+        internal string GetAliasOrDefault() => NamedEntityAttributes.Aliases.FirstOrDefault();
 
         internal RecordFieldSchema(
             NamedEntityAttributes namedEntityAttributes,


### PR DESCRIPTION
This PR reduces allocations for `Record` & `Array` readers. While profiling memory footprint of deserialization

```
Fixture fixture = new Fixture();
var data = fixture
    .Build<User>()
    .With(u => u.Offerings, fixture.CreateMany<Offering>(50).ToList)
    .CreateMany(1000)
    .ToArray();

var serialized = AvroConvert.Serialize(data);

Console.WriteLine($"Serialized {serialized.Length}");
Console.ReadLine();

var deserialized = AvroConvert.Deserialize<User[]>(serialized);

Console.WriteLine($"Deserialized {deserialized.Length} users");
```

noticed few allocations that can be removed

![image](https://github.com/AdrianStrugala/AvroConvert/assets/11509911/0ada3f4d-8e5c-4570-8d20-76673cf71041)

In particular closure & `ReadOnlyCollection<string>` allocations from `ResolveRecord`

![image](https://github.com/AdrianStrugala/AvroConvert/assets/11509911/a6a5d7f5-0b01-4b3e-b115-721c1b58aa15)

Avoid resizing list by setting its initial capacity on creation

![image](https://github.com/AdrianStrugala/AvroConvert/assets/11509911/e9a788ab-677d-4948-bc0d-d9ee543cc2e1)

As a result memory footprint improved

![image](https://github.com/AdrianStrugala/AvroConvert/assets/11509911/9a8b0ed5-7776-43a8-a7f2-3c12e44bad0a)

and ~ 9% improvement in `Deserialize` execution

| Method      | Mean     | Error    | StdDev   | Allocated |
|------------ |---------:|---------:|---------:|----------:|
| Deserialize | 62.26 ms | 1.244 ms | 1.574 ms |  30.76 MB |

VS

| Method      | Mean     | Error    | StdDev   | Allocated |
|------------ |---------:|---------:|---------:|----------:|
| Deserialize | 56.59 ms | 1.108 ms | 1.820 ms |  27.34 MB |

For reference, benchmark code

```
[MemoryDiagnoser(displayGenColumns: false)]
[HideColumns("RatioSD")]
public class ReaderBenchmarks
{
    private byte[] _serializedUsers;

    [GlobalSetup]
    public void Setup()
    {
        var fixture = new Fixture();
        var data = fixture
            .Build<User>()
            .With(u => u.Offerings, fixture.CreateMany<Offering>(50).ToList)
            .CreateMany(1000)
            .ToArray();

        _serializedUsers = AvroConvert.Serialize(data);
    }

    [Benchmark]
    public int Deserialize() => AvroConvert.Deserialize<User[]>(_serializedUsers).Length;
}
```