### PR TITLE
Fixing decimal serialization for non NET6.0 case

### DIFF
--- a/src/AvroConvert/AvroObjectServices/Write/Writer.cs
+++ b/src/AvroConvert/AvroObjectServices/Write/Writer.cs
@@ -245,7 +245,7 @@ namespace SolTechnology.Avro.AvroObjectServices.Write
 #if NET6_0_OR_GREATER
             _stream.Write(bytes);
 #else
-            throw new NotImplementedException();
+            _stream.Write(bytes.ToArray(), 0, bytes.Length);
 #endif
         }
 


### PR DESCRIPTION
Fixing decimal serialization for non NET6.0 case, which otherwise would throw `NotImplementedException`.