### PR TITLE
fix(Deserialize): fail on enums marked with Flags

### DIFF
--- a/src/AvroConvert/AvroObjectServices/Read/Resolvers/Int.cs
+++ b/src/AvroConvert/AvroObjectServices/Read/Resolvers/Int.cs
@@ -32,6 +32,9 @@ namespace SolTechnology.Avro.AvroObjectServices.Read
         {
             switch (readType)
             {
+                case not null when readType.IsEnum:
+                    return Enum.ToObject(readType, value);
+
                 case not null when readType == typeof(int):
                 case not null when readType == typeof(int?):
                     return Convert.ToInt32(value);

--- a/tests/AvroConvertTests/FullSerializationAndDeserialization/EnumTests.cs
+++ b/tests/AvroConvertTests/FullSerializationAndDeserialization/EnumTests.cs
@@ -43,6 +43,20 @@ namespace AvroConvertComponentTests.FullSerializationAndDeserialization
             //Assert
             Assert.Equal(toSerialize, deserialized);
         }
+        
+        [Theory]
+        [MemberData(nameof(TestEngine.All), MemberType = typeof(TestEngine))]
+        public void Enum_with_flags_object(Func<object, Type, dynamic> engine)
+        {
+            foreach (var toSerialize in Enum.GetValues<TestEnumWithFlags>())
+            {
+                //Act
+                var deserialized = engine.Invoke(toSerialize, typeof(TestEnumWithFlags));
+
+                //Assert
+                Assert.Equal(toSerialize, deserialized);
+            }
+        }
 
         [Theory]
         [MemberData(nameof(TestEngine.All), MemberType = typeof(TestEngine))]

--- a/tests/AvroConvertTests/TestClasses.cs
+++ b/tests/AvroConvertTests/TestClasses.cs
@@ -301,6 +301,17 @@ namespace AvroConvertComponentTests
         ca,
         dlo
     }
+    
+    [Flags]
+    public enum TestEnumWithFlags
+    {
+        None    = 0,
+        Option1 = 1,
+        Option2 = 2,
+        Option3 = 4,
+        Option4 = 8,
+        CombinedOption = Option1 | Option2
+    }
 
     [Equals(DoNotAddEqualityOperators = true)]
     public class ClassWithEnum


### PR DESCRIPTION
When working with enums marked with Flags attribute, AvroConvert serializes the value as long. On deserialize, it fails to cast it back to enum properly, causing `InvalidCastException`.

![image](https://github.com/AdrianStrugala/AvroConvert/assets/9947675/a1d425cf-a1da-491f-b452-feb19bb9cf85)


This small PR is to fix this behaviour. 