### PR TITLE
Missing decimal schema for default value resolver

### DIFF
--- a/src/AvroConvert/AvroObjectServices/BuildSchema/DefaultValueResolver.cs
+++ b/src/AvroConvert/AvroObjectServices/BuildSchema/DefaultValueResolver.cs
@@ -46,6 +46,7 @@ internal sealed class DefaultValueResolver
             { typeof(LongSchema), json => ConvertTo<long>(json) },
             { typeof(FloatSchema), json => ConvertTo<float>(json) },
             { typeof(DoubleSchema), json => ConvertTo<double>(json) },
+            { typeof(DecimalSchema), json => ConvertTo<decimal>(json) },
             { typeof(StringSchema), json => json },
             { typeof(BytesSchema), ConvertToBytes },
             { typeof(NullSchema), this.ParseNull },


### PR DESCRIPTION
This occurs when you use `[AvroDecimal]` and `[DefaultValue]` at the same time