### PR TITLE
Update EnumSchema.cs to handle Enums with duplicate values

### DIFF
--- a/src/AvroConvert/AvroObjectServices/Schemas/EnumSchema.cs
+++ b/src/AvroConvert/AvroObjectServices/Schemas/EnumSchema.cs
@@ -83,7 +83,7 @@ namespace SolTechnology.Avro.AvroObjectServices.Schemas
                     int v = Convert.ToInt32(values.GetValue(i), CultureInfo.InvariantCulture);
                     this.avroToCSharpValueMapping.Add(Convert.ToInt64(values.GetValue(i), CultureInfo.InvariantCulture));
                     this.symbolToValue.Add(this.symbols[i], v);
-                    this.valueToSymbol.Add(v, this.symbols[i]);
+                    this.valueToSymbol.TryAdd(v, this.symbols[i]);
                 }
             }
         }

--- a/src/AvroConvert/AvroObjectServices/Schemas/EnumSchema.cs
+++ b/src/AvroConvert/AvroObjectServices/Schemas/EnumSchema.cs
@@ -92,6 +92,9 @@ namespace SolTechnology.Avro.AvroObjectServices.Schemas
 
         internal bool TryGetSymbolValue(string symbol, out int value) =>
             this.symbolToValue.TryGetValue(symbol, out value);
+
+        internal int GetSymbolPosition(string symbol) =>
+            this.symbols.IndexOf(symbol);
         
         internal string GetSymbolByValue(int value)
         {

--- a/src/AvroConvert/AvroObjectServices/Write/Resolvers/Enum.cs
+++ b/src/AvroConvert/AvroObjectServices/Write/Resolvers/Enum.cs
@@ -36,14 +36,14 @@ namespace SolTechnology.Avro.AvroObjectServices.Write
                 {
                     value = EnumParser.GetEnumName(enumType, value.ToString());
                 }
-
-                if (!schema.TryGetSymbolValue(value.ToString(), out var symbolValue))
+                var position = schema.GetSymbolPosition(value.ToString());
+                if (position < 0)
                 {
                     throw new AvroTypeException(
                         $"[Enum] Provided value is not of the enum [{schema.Name}] members");
                 }
 
-                e.WriteEnum(symbolValue);
+                e.WriteEnum(position);
             };
         }
     }

--- a/tests/AvroConvertTests/FullSerializationAndDeserialization/EnumTests.cs
+++ b/tests/AvroConvertTests/FullSerializationAndDeserialization/EnumTests.cs
@@ -151,13 +151,23 @@ namespace AvroConvertComponentTests.FullSerializationAndDeserialization
         [MemberData(nameof(TestEngine.All), MemberType = typeof(TestEngine))]
         public void Enum_with_duplicate_values(Func<object, Type, dynamic> engine)
         {
-            foreach (var toSerialize in Enum.GetValues<TestDuplicateEnum>())
+            var itemsToTest =
+            new [] {
+                TestDuplicateEnum.Test,
+                TestDuplicateEnum.Exam, //Compilation already sets these values to the primary duplicate value.
+                TestDuplicateEnum.Error,
+                TestDuplicateEnum.Fail,
+                TestDuplicateEnum.TestLabel,
+                TestDuplicateEnum.TestLabel2
+            };
+            
+            foreach (var toSerialize in itemsToTest)
             {
                 //Act
                 var deserialized = engine.Invoke(toSerialize, typeof(TestDuplicateEnum));
 
                 //Assert
-                Assert.Equal(toSerialize, deserialized);
+                Assert.Equal((int)toSerialize, (int)deserialized);
             }
         }
 

--- a/tests/AvroConvertTests/FullSerializationAndDeserialization/EnumTests.cs
+++ b/tests/AvroConvertTests/FullSerializationAndDeserialization/EnumTests.cs
@@ -146,5 +146,34 @@ namespace AvroConvertComponentTests.FullSerializationAndDeserialization
             Assert.Equal(TestEnumWithMembers.Negative, deserialized.EnumPropWithDefault);
             Assert.Equal(TestEnumWithMembers.Negative, deserialized.EnumPropWithStringDefault);
         }
+
+        [Theory]
+        [MemberData(nameof(TestEngine.All), MemberType = typeof(TestEngine))]
+        public void Enum_with_duplicate_values(Func<object, Type, dynamic> engine)
+        {
+            foreach (var toSerialize in Enum.GetValues<TestDuplicateEnum>())
+            {
+                //Act
+                var deserialized = engine.Invoke(toSerialize, typeof(TestDuplicateEnum));
+
+                //Assert
+                Assert.Equal(toSerialize, deserialized);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TestEngine.All), MemberType = typeof(TestEngine))]
+        public void Class_with_enum_with_duplicate_value(Func<object, Type, dynamic> engine)
+        {
+            //Arrange
+            ClassWithDuplicateEnums toSerialize = _fixture.Create<ClassWithDuplicateEnums>();
+
+            //Act
+            var deserialized = engine.Invoke(toSerialize, typeof(ClassWithDuplicateEnums));
+
+            //Assert
+            Assert.NotNull(deserialized);
+            Assert.Equal(toSerialize, deserialized);
+        }
     }
 }

--- a/tests/AvroConvertTests/TestClasses.cs
+++ b/tests/AvroConvertTests/TestClasses.cs
@@ -353,6 +353,25 @@ namespace AvroConvertComponentTests
         public TestEnum? SecondEnumProp { get; set; }
     }
 
+    public enum TestDuplicateEnum {
+        Test = 0
+        Exam = Test,
+        Fail = -1,
+        Error = Fail,
+        TestLabel = 2,
+        TestLabel2 = 2
+    }
+
+    [Equals(DoNotAddEqualityOperators = true)]
+    public class ClassWithDuplicateEnums {
+        [DefaultValue(TestDuplicateEnum.Fail)]
+        public TestDuplicateEnum? EnumProp { get; set; }
+        [DefaultValue("Error")]
+        public TestDuplicateEnum? EnumProp2 { get; set;}
+        [DefaultValue(2)]
+        public TestDuplicateEnum? EnumProp3 { get; set; }
+    }
+
     public class ClassWithEnumDefiningMembers
     {
         public TestEnumWithMembers? EnumProp { get; set; }

--- a/tests/AvroConvertTests/TestClasses.cs
+++ b/tests/AvroConvertTests/TestClasses.cs
@@ -354,9 +354,9 @@ namespace AvroConvertComponentTests
     }
 
     public enum TestDuplicateEnum {
-        Test = 0
+        Test = 0,
         Exam = Test,
-        Fail = -1,
+        Fail = 1,
         Error = Fail,
         TestLabel = 2,
         TestLabel2 = 2


### PR DESCRIPTION
Prevent Duplicate Key Added Exception for Complex Enums that have Multiple Enum entries with the same value.  

Multiple enums with the same value are valid in C#, but this change will default the value to the first enum with said value when trying to go from a value to the enum.

### Examples

```csharp
public enum Test {
    Error = -1,
    Failure = Error
    NotStarted = 0
    Success = 1
    Awesome = Success
}
```


We have it in our codebase to have 2 letter state codes and the full state name for convenience and improved readability.
