### PR TITLE
Fix support for nullable types for AvroType attribute

### DIFF
--- a/src/AvroConvert/AvroObjectServices/Write/Resolvers/Union.cs
+++ b/src/AvroConvert/AvroObjectServices/Write/Resolvers/Union.cs
@@ -22,6 +22,7 @@ using SolTechnology.Avro.AvroObjectServices.Schemas.Abstract;
 using SolTechnology.Avro.AvroObjectServices.Schemas.AvroTypes;
 using SolTechnology.Avro.Features.Serialize;
 using SolTechnology.Avro.Infrastructure.Exceptions;
+using SolTechnology.Avro.Infrastructure.Extensions;
 
 // ReSharper disable once CheckNamespace
 namespace SolTechnology.Avro.AvroObjectServices.Write
@@ -56,19 +57,19 @@ namespace SolTechnology.Avro.AvroObjectServices.Write
                 case AvroType.Null:
                     return obj == null;
                 case AvroType.Boolean:
-                    return obj is bool;
+                    return obj is bool || typeof(bool).CanChangeTypeFrom(obj);
                 case AvroType.Int:
-                    return (obj is short or ushort or int or uint or char or byte or sbyte);
+                    return (obj is short or ushort or int or uint or char or byte or sbyte) || typeof(int).CanChangeTypeFrom(obj);
                 case AvroType.Long:
-                    return (obj is long or ulong);
+                    return (obj is long or ulong) || typeof(long).CanChangeTypeFrom(obj);
                 case AvroType.Float:
-                    return obj is float;
+                    return obj is float || typeof(float).CanChangeTypeFrom(obj);
                 case AvroType.Double:
-                    return obj is double;
+                    return obj is double || typeof(double).CanChangeTypeFrom(obj);
                 case AvroType.Bytes:
                     return obj is byte[];
                 case AvroType.String:
-                    return true;
+                    return true || typeof(string).CanChangeTypeFrom(obj);
                 case AvroType.Error:
                     return true;
                 case AvroType.Record:

--- a/src/AvroConvert/Infrastructure/Extensions/TypeExtensions.cs
+++ b/src/AvroConvert/Infrastructure/Extensions/TypeExtensions.cs
@@ -446,5 +446,19 @@ namespace SolTechnology.Avro.Infrastructure.Extensions
         {
             return type.GetTypeInfo().BaseType;
         }
+
+        internal static bool CanChangeTypeFrom(this Type type, object value)
+        {
+            try
+            {
+                _ = Convert.ChangeType(value, type);
+
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
     }
 }

--- a/tests/AvroConvertTests/DefaultOnly/AvroAttributeClassTests.cs
+++ b/tests/AvroConvertTests/DefaultOnly/AvroAttributeClassTests.cs
@@ -86,5 +86,49 @@ namespace AvroConvertComponentTests.DefaultOnly
             Assert.Equal(toSerialize.Int, deserialized.Int);
             toSerialize.DateTime.Should().BeCloseTo(deserialized.DateTime, TimeSpan.FromMilliseconds(1)); //milliseconds precision
         }
+
+        [Theory]
+        [MemberData(nameof(TestEngine.DefaultOnly), MemberType = typeof(TestEngine))]
+        public void AvroTypeAttribute_overwrites_nullable_default_type_mapping(Func<object, Type, dynamic> engine)
+        {
+            //Arrange
+            NullableTypeAttributeClass toSerialize = _fixture.Create<NullableTypeAttributeClass>();
+
+            //Act
+            var schema = AvroConvert.GenerateSchema(typeof(NullableTypeAttributeClass));
+
+            var deserialized = (NullableTypeAttributeClass)engine.Invoke(toSerialize, typeof(NullableTypeAttributeClass));
+
+
+            //Assert
+            Assert.Equal("{\"name\":\"NullableTypeAttributeClass\",\"namespace\":\"AvroConvertComponentTests\",\"type\":\"record\",\"fields\":[{\"name\":\"Int\",\"type\":[\"null\",\"double\"]},{\"name\":\"DateTime\",\"type\":[\"null\",{\"type\":\"long\",\"logicalType\":\"timestamp-millis\"}]}]}", schema);
+            Assert.NotNull(deserialized);
+            Assert.Equal(toSerialize.Int, deserialized.Int);
+            toSerialize.DateTime.Should().BeCloseTo(deserialized.DateTime.Value, TimeSpan.FromMilliseconds(1)); //milliseconds precision
+        }
+
+        [Theory]
+        [MemberData(nameof(TestEngine.DefaultOnly), MemberType = typeof(TestEngine))]
+        public void AvroTypeAttribute_overwrites_nullable_default_type_mapping_in_array(Func<object, Type, dynamic> engine)
+        {
+            //Arrange
+            NestedTypeAttributeClass toSerialize = _fixture.Create<NestedTypeAttributeClass>();
+
+            //Act
+            var schema = AvroConvert.GenerateSchema(typeof(NestedTypeAttributeClass));
+
+            var deserialized = (NestedTypeAttributeClass)engine.Invoke(toSerialize, typeof(NestedTypeAttributeClass));
+
+
+            //Assert
+            Assert.Equal("{\"name\":\"NestedTypeAttributeClass\",\"namespace\":\"AvroConvertComponentTests\",\"type\":\"record\",\"fields\":[{\"name\":\"Items\",\"type\":{\"type\":\"array\",\"items\":{\"name\":\"NullableTypeAttributeClass\",\"namespace\":\"AvroConvertComponentTests\",\"type\":\"record\",\"fields\":[{\"name\":\"Int\",\"type\":[\"null\",\"double\"]},{\"name\":\"DateTime\",\"type\":[\"null\",{\"type\":\"long\",\"logicalType\":\"timestamp-millis\"}]}]}}}]}", schema);
+            Assert.NotNull(deserialized);
+
+            for (var i = 0; i < toSerialize.Items.Length; i++)
+            {
+                Assert.Equal(toSerialize.Items[i].Int, deserialized.Items[i].Int);
+                toSerialize.Items[i].DateTime.Should().BeCloseTo(deserialized.Items[i].DateTime.Value, TimeSpan.FromMilliseconds(1)); //milliseconds precision
+            }
+        }
     }
 }

--- a/tests/AvroConvertTests/TestClasses.cs
+++ b/tests/AvroConvertTests/TestClasses.cs
@@ -262,6 +262,20 @@ namespace AvroConvertComponentTests
         public DateTime DateTime;
     }
 
+    public class NullableTypeAttributeClass
+    {
+        [AvroType(AvroTypeRepresentation.Double)]
+        public int? Int;
+
+        [AvroType(AvroTypeRepresentation.TimestampMilliseconds)]
+        public DateTime? DateTime;
+    }
+
+    public class NestedTypeAttributeClass
+    {
+        public NullableTypeAttributeClass[] Items;
+    }
+
     public struct ComplexStruct
     {
         [DataMember]


### PR DESCRIPTION
Fixes: #167 

@AdrianStrugala for your review please, this issue is preventing some key work on our side.

I'm slightly nervous that there are some edge cases with this or unepxected behaviours not catered for. For example, declaring a `byte[]` property, but using `AvroType(Decimal)` or something bizarre. I've added some additional unit tests to cover some of the edge cases I've found.