### PR TITLE
Fix naming policy for enums

### DIFF
--- a/src/AvroConvert/AvroObjectServices/BuildSchema/AvroContractResolver.cs
+++ b/src/AvroConvert/AvroObjectServices/BuildSchema/AvroContractResolver.cs
@@ -92,10 +92,28 @@ namespace SolTechnology.Avro.AvroObjectServices.BuildSchema
                 type.IsNativelySupported() ||
                 (type.IsEnum() && !type.GetTypeInfo().GetCustomAttributes(false).OfType<DataContractAttribute>().Any()))
             {
+                var typeName = type.Name;
+                var typeNamespace = type.Namespace;
+
+                if (type.IsEnum() && _namingPolicy != null)
+                {
+                    var naming = _namingPolicy.GetTypeName(type);
+
+                    if (!string.IsNullOrEmpty(naming?.Name))
+                    {
+                        typeName = naming.Name;
+                    }
+
+                    if (!string.IsNullOrEmpty(naming?.Namespace))
+                    {
+                        typeNamespace = naming.Namespace;
+                    }
+                }
+
                 return new TypeSerializationInfo
                 {
-                    Name = SolTechnology.Avro.Infrastructure.Extensions.TypeExtensions.StripAvroNonCompatibleCharacters(type.Name),
-                    Namespace = SolTechnology.Avro.Infrastructure.Extensions.TypeExtensions.StripAvroNonCompatibleCharacters(type.Namespace),
+                    Name = SolTechnology.Avro.Infrastructure.Extensions.TypeExtensions.StripAvroNonCompatibleCharacters(typeName),
+                    Namespace = SolTechnology.Avro.Infrastructure.Extensions.TypeExtensions.StripAvroNonCompatibleCharacters(typeNamespace),
                     Nullable = isNullable
                 };
             }

--- a/tests/AvroConvertTests/GenerateSchema/NamingPolicyTypeTests.cs
+++ b/tests/AvroConvertTests/GenerateSchema/NamingPolicyTypeTests.cs
@@ -21,7 +21,7 @@ public class NamingPolicyTypeTests
         //Assert
         Assert.Contains("\"name\":\"BasicTypeWithProperties\",\"namespace\":\"com.company.product\"", schema);
         Assert.Contains("\"name\":\"BaseClass\",\"namespace\":\"com.company.product\"", schema);
-        Assert.Contains("\"name\":\"EnumWithDifferentNames\",\"namespace\":\"AvroConvertComponentTests\"", schema);
+        Assert.Contains("\"name\":\"EnumWithDifferentNames\",\"namespace\":\"com.company.product\"", schema);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes: #172

So sorry @AdrianStrugala, not sure how I missed this edge case. The unit test was staring me in the face too 😮. This fixes an issue where non-null enums without a `DataAttribute` were not being picked up by the naming policy.