### PR TITLE
Add number handling options to round/truncate decimals

### DIFF
--- a/src/AvroConvert/AvroConvert.SerializeHeadless.cs
+++ b/src/AvroConvert/AvroConvert.SerializeHeadless.cs
@@ -27,12 +27,12 @@ namespace SolTechnology.Avro
         /// <summary>
         /// Serializes given object to Avro format - <c>excluding</c> header
         /// </summary>
-        public static byte[] SerializeHeadless(object obj, string schema)
+        public static byte[] SerializeHeadless(object obj, string schema, AvroConvertOptions options = null)
         {
             MemoryStream resultStream = new MemoryStream();
             var encoder = new Writer(resultStream);
             var schemaObject = Schema.Parse(schema);
-            var resolver = new WriteResolver();
+            var resolver = new WriteResolver(options);
             var writer = resolver.ResolveWriter(schemaObject);
 
             writer(obj, encoder);
@@ -44,12 +44,12 @@ namespace SolTechnology.Avro
         /// <summary>
         /// Serializes given object to Avro format - <c>excluding</c> header
         /// </summary>
-        public static byte[] SerializeHeadless(object obj, Type objectType)
+        public static byte[] SerializeHeadless(object obj, Type objectType, AvroConvertOptions options = null)
         {
             MemoryStream resultStream = new MemoryStream();
             var encoder = new Writer(resultStream);
             var schemaObject = BuildSchema(objectType);
-            var resolver = new WriteResolver();
+            var resolver = new WriteResolver(options);
             var writer = resolver.ResolveWriter(schemaObject);
 
             writer(obj, encoder);

--- a/src/AvroConvert/AvroConvertOptions.cs
+++ b/src/AvroConvert/AvroConvertOptions.cs
@@ -69,4 +69,9 @@ public class AvroConvertOptions
     /// Gets or sets the naming policy that can determine how types and fields are named.
     /// </summary>
     public IAvroNamingPolicy NamingPolicy { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number handling behavior for Avro types.
+    /// </summary>
+    public AvroNumberHandling NumberHandling { get; set; }
 }

--- a/src/AvroConvert/AvroObjectServices/Write/Resolvers/Decimal.cs
+++ b/src/AvroConvert/AvroObjectServices/Write/Resolvers/Decimal.cs
@@ -20,6 +20,7 @@ using SolTechnology.Avro.AvroObjectServices.Schemas;
 using SolTechnology.Avro.AvroObjectServices.Schemas.AvroTypes;
 using SolTechnology.Avro.Features.Serialize;
 using SolTechnology.Avro.Infrastructure.Exceptions;
+using SolTechnology.Avro.Policies;
 
 // ReSharper disable once CheckNamespace
 namespace SolTechnology.Avro.AvroObjectServices.Write
@@ -36,11 +37,32 @@ namespace SolTechnology.Avro.AvroObjectServices.Write
             int sizeDiff = logicalScale - scale;
             if (sizeDiff < 0)
             {
-                throw new AvroTypeException(
-                    $@"Decimal Scale for value [{logicalValue}] is equal to [{scale}]. This exceeds default setting [{logicalScale}].
+                if (_numberHandling == AvroNumberHandling.Strict)
+                {
+                    throw new AvroTypeException(
+                        $@"Decimal Scale for value [{logicalValue}] is equal to [{scale}]. This exceeds default setting [{logicalScale}].
 Consider adding following attribute to your property:
 [AvroDecimal(Precision = 28, Scale = {scale})]
 ");
+                }
+
+                if (_numberHandling == AvroNumberHandling.Truncate)
+                {
+                    var multiplier = (decimal)Math.Pow(10, logicalScale);
+                    var truncatedValue = Math.Truncate((decimal)logicalValue * multiplier) / multiplier;
+
+                    logicalValue = truncatedValue;
+                    avroDecimal = new AvroDecimal(truncatedValue);
+                    sizeDiff = 0;
+                }
+                else if (_numberHandling == AvroNumberHandling.Rounding)
+                {
+                    var roundedValue = Math.Round((decimal)logicalValue, logicalScale);
+
+                    logicalValue = roundedValue;
+                    avroDecimal = new AvroDecimal(roundedValue);
+                    sizeDiff = 0;
+                }
             }
 
             string trailingZeros = new string('0', sizeDiff);

--- a/src/AvroConvert/AvroObjectServices/Write/WriteResolver.cs
+++ b/src/AvroConvert/AvroObjectServices/Write/WriteResolver.cs
@@ -35,6 +35,7 @@ namespace SolTechnology.Avro.AvroObjectServices.Write
         private static bool _hasCustomConverters;
         private readonly Dictionary<Type, Action<object, IWriter>> _customSerializerMapping;
         private readonly IAvroNamingPolicy _namingPolicy;
+        private readonly AvroNumberHandling _numberHandling;
 
         internal WriteResolver(AvroConvertOptions options = null)
         {
@@ -43,6 +44,7 @@ namespace SolTechnology.Avro.AvroObjectServices.Write
                 x => x.TypeSchema.RuntimeType,
                 y => (Action<object, IWriter>)y.Serialize);
             _namingPolicy = options?.NamingPolicy;
+            _numberHandling = options?.NumberHandling ?? AvroNumberHandling.Strict;
         }
 
         internal Encoder.WriteItem ResolveWriter(TypeSchema schema)

--- a/src/AvroConvert/Policies/AvroNumberHandling.cs
+++ b/src/AvroConvert/Policies/AvroNumberHandling.cs
@@ -1,0 +1,19 @@
+namespace SolTechnology.Avro.Policies;
+
+public enum AvroNumberHandling
+{
+    /// <summary>
+    /// Decimals that are too large for the defined scale are rejected.
+    /// </summary>
+    Strict,
+
+    /// <summary>
+    /// Decimals that are too large for the defined scale are truncated.
+    /// </summary>
+    Truncate,
+
+    /// <summary>
+    /// Decimals that are too large for the defined scale are rounded.
+    /// </summary>
+    Rounding
+}

--- a/tests/AvroConvertTests/FullSerializationAndDeserialization/NumberTests.cs
+++ b/tests/AvroConvertTests/FullSerializationAndDeserialization/NumberTests.cs
@@ -1,0 +1,40 @@
+using System;
+using Xunit;
+
+namespace AvroConvertComponentTests.FullSerializationAndDeserialization;
+
+public class NumberTests
+{
+    [Theory]
+    [MemberData(nameof(TestEngine.Core), MemberType = typeof(TestEngine))]
+    public void Class_WithTooBigDecimal_ShouldThrow_ByDefault(Func<object, Type, dynamic> engine)
+    {
+        //Arrange
+        var record = new LogicalTypesClass();
+        record.One = 1.12345678901234567890m; // Default scale is 14
+
+        //Act
+        var exception = Record.Exception(() => engine.Invoke(record, typeof(LogicalTypesClass)));
+
+        //Assert
+        Assert.NotNull(exception);
+    }
+
+    [Theory]
+    [MemberData(nameof(TestEngine.HeadlessUsingNumberHandling), MemberType = typeof(TestEngine))]
+    public void Class_WithTooBigDecimal_ShouldTruncateOrRound_UsingHandling(Func<object, Type, dynamic> engine)
+    {
+        //Arrange
+        var record = new LogicalTypesClass();
+        record.One = 1.12345678901234567890m; // Default scale is 14
+
+        //Act
+        var deserialized = engine.Invoke(record, typeof(LogicalTypesClass));
+        var value = (decimal)deserialized.One;
+
+        //Assert
+        Assert.NotNull(deserialized);
+        Assert.Equal(14, value.Scale);
+        Assert.True(value >= 1.12345678901234m && value <= 1.12345678901235m);
+    }
+}

--- a/tests/AvroConvertTests/FullSerializationAndDeserialization/NumberTests.cs
+++ b/tests/AvroConvertTests/FullSerializationAndDeserialization/NumberTests.cs
@@ -34,7 +34,19 @@ public class NumberTests
 
         //Assert
         Assert.NotNull(deserialized);
-        Assert.Equal(14, value.Scale);
+        Assert.Equal(14, GetScale(value));
         Assert.True(value >= 1.12345678901234m && value <= 1.12345678901235m);
+    }
+
+    private int GetScale(decimal value)
+    {
+        if (value == 0)
+        {
+            return 0;
+        }
+
+        var bits = decimal.GetBits(value);
+
+        return (bits[3] >> 16) & 0x7F;
     }
 }

--- a/tests/AvroConvertTests/TestEngine.cs
+++ b/tests/AvroConvertTests/TestEngine.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using Newtonsoft.Json;
 using SolTechnology.Avro;
+using SolTechnology.Avro.Policies;
 
 namespace AvroConvertComponentTests;
 
@@ -52,6 +53,13 @@ public static class TestEngine
         yield return BrotliWithSchema;
     }
 
+    public static IEnumerable<object[]> HeadlessUsingNumberHandling()
+    {
+        yield return HeadlessWithTruncateNumberHandling;
+
+        yield return HeadlessWithRoundingNumberHandling;
+    }
+
     public static IEnumerable<object[]> DefaultOnly()
     {
         yield return Default;
@@ -91,6 +99,38 @@ public static class TestEngine
             {
                 var schema = AvroConvert.GenerateSchema(type);
                 var serialized = AvroConvert.SerializeHeadless(input, schema);
+                return AvroConvert.DeserializeHeadless(serialized, type);
+            });
+
+            return new object[] { headless };
+        }
+    }
+
+    private static object[] HeadlessWithTruncateNumberHandling
+    {
+        get
+        {
+            var headless = new Func<object, Type, dynamic>((input, type) =>
+            {
+                var schema = AvroConvert.GenerateSchema(type);
+                var options = new AvroConvertOptions { NumberHandling = AvroNumberHandling.Truncate };
+                var serialized = AvroConvert.SerializeHeadless(input, schema, options);
+                return AvroConvert.DeserializeHeadless(serialized, type);
+            });
+
+            return new object[] { headless };
+        }
+    }
+
+    private static object[] HeadlessWithRoundingNumberHandling
+    {
+        get
+        {
+            var headless = new Func<object, Type, dynamic>((input, type) =>
+            {
+                var schema = AvroConvert.GenerateSchema(type);
+                var options = new AvroConvertOptions { NumberHandling = AvroNumberHandling.Rounding };
+                var serialized = AvroConvert.SerializeHeadless(input, schema, options);
                 return AvroConvert.DeserializeHeadless(serialized, type);
             });
 


### PR DESCRIPTION
We find ourselves constantly hitting the error message that our decimals do not fit into the scale/precision of the defined Avro schema. This change adds an opt-in handling for decimals that fall outside of the decimal schema with either truncating or rounding.

The default behavior is preserved, so large decimals will continue to throw an exception when writing a decimal value.