### PR TITLE
Fix reading records when additional fields exist and should be skipped

### DIFF
--- a/src/AvroConvert/AvroObjectServices/Read/Resolvers/Record.cs
+++ b/src/AvroConvert/AvroObjectServices/Read/Resolvers/Record.cs
@@ -1,4 +1,4 @@
-﻿#region license
+#region license
 
 /**Copyright (c) 2023 Adrian Strugała
 *
@@ -97,15 +97,16 @@ namespace SolTechnology.Avro.AvroObjectServices.Read
                         if (readStepValue.ShouldSkip)
                         {
                             _skipper.Skip(readStepValue.WriteFieldSchema.TypeSchema, reader);
-                            break;
                         }
-
-                        accessor[result, readStep.Key] =
-                            GetValue(
-                                readStepValue.WriteFieldSchema,
-                                readStepValue.ReadFieldSchema,
-                                readStepValue.MemberInfo,
-                                reader);
+                        else
+                        {
+                            accessor[result, readStep.Key] =
+                                GetValue(
+                                    readStepValue.WriteFieldSchema,
+                                    readStepValue.ReadFieldSchema,
+                                    readStepValue.MemberInfo,
+                                    reader);
+                        }
                     }
                 }
 

--- a/tests/AvroConvertTests/FullSerializationAndDeserialization/ClassesWithMismatchedFieldsTests.cs
+++ b/tests/AvroConvertTests/FullSerializationAndDeserialization/ClassesWithMismatchedFieldsTests.cs
@@ -1,0 +1,79 @@
+using SolTechnology.Avro;
+using Xunit;
+
+namespace AvroConvertComponentTests.FullSerializationAndDeserialization
+{
+    public class ClassesWithMismatchedFieldsTests
+    {
+        [Fact]
+        public void Write_schema_with_additional_field_in_array_can_be_read()
+        {
+            //Arrange
+            var write = new WriteModel
+            {
+                Models =
+                [
+                    new WriteModelWithAdditionalField
+                    {
+                        StringValue = "string value",
+                        DecimalValue = 123.456m,
+                        IntValue = 10
+                    },
+                    new WriteModelWithAdditionalField
+                    {
+                        StringValue = "string value",
+                        DecimalValue = 123.456m,
+                        IntValue = 10
+                    }
+                ],
+                FinalField = 456.789m
+            };
+
+            var writeSchema = AvroConvert.GenerateSchema(typeof(WriteModel));
+            var readSchema = AvroConvert.GenerateSchema(typeof(ReadModel));
+
+            //Act
+            var serialized = AvroConvert.SerializeHeadless(write, writeSchema);
+            var result = AvroConvert.DeserializeHeadless(serialized, writeSchema, readSchema, typeof(ReadModel)) as ReadModel;
+
+            //Assert
+            Assert.NotNull(result);
+            Assert.Equal(2, result.Models.Length);
+            Assert.Equal("string value", result.Models[0].StringValue);
+            Assert.Equal(10, result.Models[0].IntValue);
+            Assert.Equal("string value", result.Models[1].StringValue);
+            Assert.Equal(10, result.Models[1].IntValue);
+            Assert.Equal(456.789m, result.FinalField);
+        }
+
+        public class WriteModel
+        {
+            public WriteModelWithAdditionalField[] Models { get; set; }
+
+            public decimal FinalField { get; set; }
+        }
+
+        public class WriteModelWithAdditionalField
+        {
+            public string StringValue { get; set; }
+
+            public decimal DecimalValue { get; set; }
+
+            public int IntValue { get; set; }
+        }
+
+        public class ReadModel
+        {
+            public ReadModelWithMissingField[] Models { get; set; }
+
+            public decimal FinalField { get; set; }
+        }
+
+        public class ReadModelWithMissingField
+        {
+            public string StringValue { get; set; }
+
+            public int IntValue { get; set; }
+        }
+    }
+}

--- a/tests/AvroConvertTests/FullSerializationAndDeserialization/ClassesWithMismatchedFieldsTests.cs
+++ b/tests/AvroConvertTests/FullSerializationAndDeserialization/ClassesWithMismatchedFieldsTests.cs
@@ -11,8 +11,8 @@ namespace AvroConvertComponentTests.FullSerializationAndDeserialization
             //Arrange
             var write = new WriteModel
             {
-                Models =
-                [
+                Models = new[]
+                {
                     new WriteModelWithAdditionalField
                     {
                         StringValue = "string value",
@@ -25,7 +25,7 @@ namespace AvroConvertComponentTests.FullSerializationAndDeserialization
                         DecimalValue = 123.456m,
                         IntValue = 10
                     }
-                ],
+                },
                 FinalField = 456.789m
             };
 


### PR DESCRIPTION
Fixes: #151 (possibly)

_Not sure if this fixes the above issue, but we encountered exactly this error recently._

### Setup
We have a write schema which has an additional field in an array schema. This field has been added in the middle of the other fields, which is a valid Avro schema change. The array has multiple items in it. Our read schema does not have this field, and we expect the field to be skipped correctly.

### Behavior observed
The first array item to be read is processed correctly, and the read steps are cached. However the 2nd read, which uses those cached steps, aborts on the first occurrence of a "skipped" field, and leaves the rest of the byte stream for the array item untouched. A subsequent read of any field results in incorrectly parsed values and exceptions. In our case we saw stack overflow, but also saw other "bad format" etc exceptions as well.

### Fix
The fix is to continue reading the fields when a "skipped" field is encountered. This is already the behavior for 'first reads' of an object, this just mirrors the behavior for the cached steps as well. I've also added a very specific unit test which tests this behavior.